### PR TITLE
feat: tinker debugging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ DEVELOPMENT.md
 .phpunit.result.cache
 .phpstan.cache/
 /dev/
+/docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `logLevel` configuration option to control MCP server log verbosity (`storage/logs/mcp-server.log`). Set to `'debug'` for full tool dispatch logging. Default: `'error'` ([#10](https://github.com/stimmtdigital/craft-mcp/issues/10))
+- Debug logging in `tinker` tool for execution tracing, security blocks, and error diagnostics
+
+### Fixed
+- `tinker` tool now wraps execution in `SafeExecution`, ensuring unexpected errors surface with real messages instead of the generic "Tool execution failed" ([#10](https://github.com/stimmtdigital/craft-mcp/issues/10))
+
 ## [1.2.2] - 2026-03-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `tinker` tool now wraps execution in `SafeExecution`, ensuring unexpected errors surface with real messages instead of the generic "Tool execution failed" ([#10](https://github.com/stimmtdigital/craft-mcp/issues/10))
+- Stray output (echo/print/PHP notices from tinker'd code or Craft) no longer corrupts the stdio JSON-RPC stream; it is rerouted to stderr via a non-removable output buffer in `bin/mcp-server`
+- `tinker` tool blocks unbounded `while (ob_get_level())` teardown loops, which would spin forever against the non-removable stdout shield
 
 ## [1.2.2] - 2026-03-04
 

--- a/bin/mcp-server
+++ b/bin/mcp-server
@@ -87,8 +87,12 @@ try {
     $settings = Mcp::settings();
     $logger = McpServerFactory::createFileLogger(logLevel: $settings->logLevel);
 
-    // Register logger for tool constructor injection (e.g. TinkerTools)
+    // Register logger so Yii can inject it into tool constructors.
+    // TinkerTools must also be registered so the SDK's container lookup
+    // finds it via Psr11ContainerAdapter::has() instead of falling back
+    // to bare instantiation (which would skip DI and use NullLogger).
     Craft::$container->setSingleton(\Psr\Log\LoggerInterface::class, fn() => $logger);
+    Craft::$container->set(\stimmt\craft\Mcp\tools\TinkerTools::class);
 
     $factory = new McpServerFactory(logger: $logger);
     $server = $factory->create();

--- a/bin/mcp-server
+++ b/bin/mcp-server
@@ -84,7 +84,12 @@ $signalHandler->register();
 
 // Build and run server with dedicated file logger (separate from Craft logs)
 try {
-    $logger = McpServerFactory::createFileLogger();
+    $settings = Mcp::settings();
+    $logger = McpServerFactory::createFileLogger(logLevel: $settings->logLevel);
+
+    // Register logger for tool constructor injection (e.g. TinkerTools)
+    Craft::$container->setSingleton(\Psr\Log\LoggerInterface::class, fn() => $logger);
+
     $factory = new McpServerFactory(logger: $logger);
     $server = $factory->create();
     $transport = $factory->createTransport();

--- a/bin/mcp-server
+++ b/bin/mcp-server
@@ -16,6 +16,24 @@ declare(strict_types=1);
  *   ddev exec php vendor/stimmt/craft-mcp/bin/mcp-server
  */
 
+// Shield the stdio transport: stdout is the JSON-RPC stream, so any stray
+// echo/print or PHP notice (from tinker'd code, Craft deprecations, etc.)
+// would corrupt the protocol framing. This non-removable output buffer
+// reroutes all echo-style output to stderr. The transport is unaffected:
+// it writes frames via fwrite(STDOUT), which bypasses output buffering.
+// CLEANABLE keeps Yii-style bounded ob_clean() fallbacks working.
+ob_start(
+    static function (string $buffer): string {
+        if ($buffer !== '') {
+            fwrite(STDERR, $buffer);
+        }
+
+        return '';
+    },
+    1,
+    PHP_OUTPUT_HANDLER_CLEANABLE,
+);
+
 // Find Craft's base path by looking for bootstrap.php
 $basePath = null;
 $currentDir = __DIR__;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,12 @@ return [
         '127.0.0.1',
         '::1',
     ],
+
+    // Minimum log level for the MCP server log (storage/logs/mcp-server.log).
+    // Set to 'debug' to see tool invocations, arguments, and execution details.
+    // Valid values: 'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'
+    // Default: 'error'
+    'logLevel' => 'error',
 ];
 ```
 
@@ -58,6 +64,7 @@ return [
 | `enableDangerousTools` | `bool` | `false` (prod) / `true` (other) | Whether tools that modify data or execute code are available |
 | `disabledTools` | `array` | `[]` | List of tool names to disable regardless of other settings |
 | `allowedIps` | `array` | `[]` | IP addresses allowed to connect (empty = all allowed) |
+| `logLevel` | `string` | `'error'` | Minimum log level for `storage/logs/mcp-server.log` |
 
 ## Environment Variables
 
@@ -187,6 +194,27 @@ If you want to allow most tools but restrict a few specific ones, use the `disab
 ```
 
 Tools listed here are disabled regardless of the `enableDangerousTools` setting. Use the snake_case tool name as shown in the [Tools Reference](tools/README.md).
+
+## Debugging
+
+The MCP server writes logs to `storage/logs/mcp-server.log`, separate from Craft's own logging. By default, only errors are logged. To enable verbose logging for troubleshooting tool failures:
+
+```php
+'logLevel' => 'debug',
+```
+
+With debug logging enabled, the log includes:
+- Tool invocations with name and arguments (from the MCP SDK)
+- Tinker-specific events: code being executed, security pattern blocks, and caught errors
+- Execution results and timing
+
+After changing the log level, restart the MCP server (send SIGHUP to the process, or restart your AI client).
+
+### Common Issues
+
+**"Tool execution failed" with no detail**: This typically means an unexpected error occurred outside the tool's error handling. Check `storage/logs/mcp-server.log` for the full exception. Enable `'logLevel' => 'debug'` for additional context.
+
+**Tinker returns no output**: Verify that `enableDangerousTools` is `true` and that `tinker` is not in the `disabledTools` array. Check with the `list_mcp_tools` tool to confirm tinker is listed as enabled.
 
 ## Next Steps
 

--- a/src/Mcp.php
+++ b/src/Mcp.php
@@ -264,7 +264,7 @@ class Mcp extends BasePlugin {
             ? $definition->dangerous
             : in_array($toolName, self::DANGEROUS_TOOLS, true); // Fallback for backwards compat
 
-        return !($isDangerous && !$settings->enableDangerousTools);
+        return !$isDangerous || $settings->enableDangerousTools;
     }
 
     /**

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -31,6 +31,8 @@ class Settings extends Model {
     /** @var string[] */
     public array $allowedIps = [];
 
+    public string $logLevel = 'error';
+
     /**
      * @return array<int, array<int|string, mixed>>
      */
@@ -39,6 +41,7 @@ class Settings extends Model {
         return [
             [['enabled', 'enableDangerousTools'], 'boolean'],
             [['disabledTools', 'disabledPrompts', 'disabledResources', 'allowedIps'], 'each', 'rule' => ['string']],
+            [['logLevel'], 'in', 'range' => ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']],
         ];
     }
 }

--- a/src/resources/SchemaResources.php
+++ b/src/resources/SchemaResources.php
@@ -151,7 +151,7 @@ final class SchemaResources {
                     'type' => SchemaHelper::getFieldTypeName($field),
                     'instructions' => $field->instructions !== '' ? $field->instructions : null,
                     'searchable' => $field->searchable,
-                    'translationMethod' => $field->translationMethod ?? 'none',
+                    'translationMethod' => $field->translationMethod,
                 ],
                 'usedIn' => SchemaHelper::findFieldUsage($handle),
             ];

--- a/src/services/McpServerFactory.php
+++ b/src/services/McpServerFactory.php
@@ -65,12 +65,12 @@ class McpServerFactory {
      * Create a file logger that writes to storage/logs/mcp-server.log.
      * This is separate from Craft's logging system.
      */
-    public static function createFileLogger(?string $logPath = null): LoggerInterface {
+    public static function createFileLogger(?string $logPath = null, string $logLevel = 'error'): LoggerInterface {
         if ($logPath === null) {
             $logPath = Craft::getAlias('@storage/logs/mcp-server.log');
         }
 
-        return new FileLogger($logPath);
+        return new FileLogger($logPath, $logLevel);
     }
 
     private function getInstructions(): string {

--- a/src/support/FileLogger.php
+++ b/src/support/FileLogger.php
@@ -35,17 +35,23 @@ class FileLogger extends AbstractLogger {
         'emergency' => 7,
     ];
 
+    private readonly string $minLevel;
+
     private ?DateTimeZone $timezone = null;
 
     public function __construct(
         private readonly string $logPath,
-        private readonly string $minLevel = 'error',
+        string $minLevel = 'error',
     ) {
+        $minLevel = strtolower($minLevel);
+
         if (!array_key_exists($minLevel, self::LEVEL_PRIORITY)) {
             throw new InvalidArgumentException(
                 "Invalid log level '{$minLevel}'. Must be one of: " . implode(', ', array_keys(self::LEVEL_PRIORITY)),
             );
         }
+
+        $this->minLevel = $minLevel;
 
         $this->ensureDirectoryExists();
         $this->initializeTimezone();

--- a/src/support/FileLogger.php
+++ b/src/support/FileLogger.php
@@ -23,9 +23,29 @@ use Throwable;
  *   $logger->error('Tool execution failed', ['tool' => 'tinker', 'error' => $e->getMessage()]);
  */
 class FileLogger extends AbstractLogger {
+    private const array LEVEL_PRIORITY = [
+        'debug'     => 0,
+        'info'      => 1,
+        'notice'    => 2,
+        'warning'   => 3,
+        'error'     => 4,
+        'critical'  => 5,
+        'alert'     => 6,
+        'emergency' => 7,
+    ];
+
     private ?DateTimeZone $timezone = null;
 
-    public function __construct(private readonly string $logPath) {
+    public function __construct(
+        private readonly string $logPath,
+        private readonly string $minLevel = 'error',
+    ) {
+        if (!array_key_exists($minLevel, self::LEVEL_PRIORITY)) {
+            throw new \InvalidArgumentException(
+                "Invalid log level '{$minLevel}'. Must be one of: " . implode(', ', array_keys(self::LEVEL_PRIORITY))
+            );
+        }
+
         $this->ensureDirectoryExists();
         $this->initializeTimezone();
     }
@@ -37,14 +57,33 @@ class FileLogger extends AbstractLogger {
      * @param array<string, mixed> $context
      */
     public function log($level, string|Stringable $message, array $context = []): void {
+        if ($this->levelPriority($level) < $this->levelPriority($this->minLevel)) {
+            return;
+        }
+
         $timestamp = $this->getTimestamp();
-        $levelString = is_string($level) ? $level : (is_object($level) && method_exists($level, '__toString') ? (string) $level : 'INFO');
-        $levelUpper = strtoupper($levelString);
+        $levelUpper = strtoupper($this->levelToString($level));
         $contextJson = $context !== [] ? ' ' . json_encode($context, JSON_UNESCAPED_SLASHES) : '';
 
         $line = "[{$timestamp}] [{$levelUpper}] {$message}{$contextJson}\n";
 
         file_put_contents($this->logPath, $line, FILE_APPEND | LOCK_EX);
+    }
+
+    private function levelPriority(mixed $level): int {
+        return self::LEVEL_PRIORITY[strtolower($this->levelToString($level))] ?? 3;
+    }
+
+    private function levelToString(mixed $level): string {
+        if (is_string($level)) {
+            return $level;
+        }
+
+        if (is_object($level) && method_exists($level, '__toString')) {
+            return (string) $level;
+        }
+
+        return 'info';
     }
 
     private function ensureDirectoryExists(): void {

--- a/src/support/FileLogger.php
+++ b/src/support/FileLogger.php
@@ -9,6 +9,7 @@ use craft\config\GeneralConfig;
 use craft\services\Config;
 use DateTimeImmutable;
 use DateTimeZone;
+use InvalidArgumentException;
 use Psr\Log\AbstractLogger;
 use Stringable;
 use Throwable;
@@ -41,8 +42,8 @@ class FileLogger extends AbstractLogger {
         private readonly string $minLevel = 'error',
     ) {
         if (!array_key_exists($minLevel, self::LEVEL_PRIORITY)) {
-            throw new \InvalidArgumentException(
-                "Invalid log level '{$minLevel}'. Must be one of: " . implode(', ', array_keys(self::LEVEL_PRIORITY))
+            throw new InvalidArgumentException(
+                "Invalid log level '{$minLevel}'. Must be one of: " . implode(', ', array_keys(self::LEVEL_PRIORITY)),
             );
         }
 

--- a/src/tools/GraphqlTools.php
+++ b/src/tools/GraphqlTools.php
@@ -235,7 +235,7 @@ class GraphqlTools {
             'name' => $schema->name,
             'scope' => $schema->scope,
             'permissions' => $this->parseScope($schema->scope),
-            'isPublic' => $schema->isPublic ?? false,
+            'isPublic' => $schema->isPublic,
         ];
     }
 

--- a/src/tools/TinkerTools.php
+++ b/src/tools/TinkerTools.php
@@ -123,12 +123,18 @@ class TinkerTools {
                     $stdout ?: null,
                 );
             } catch (ParseErrorException|ParseError $e) {
-                ob_end_clean();
+                if (ob_get_level() > 0) {
+                    ob_end_clean();
+                }
+
                 $this->logger->debug('Tinker caught error', ['error' => $e->getMessage()]);
 
                 return $this->response($code, $this->formatError('ParseError', $e->getMessage()));
             } catch (Throwable $e) {
-                ob_end_clean();
+                if (ob_get_level() > 0) {
+                    ob_end_clean();
+                }
+
                 $this->logger->debug('Tinker caught error', ['error' => $e->getMessage()]);
 
                 return $this->response($code, $this->formatError($e::class, $e->getMessage(), $e));

--- a/src/tools/TinkerTools.php
+++ b/src/tools/TinkerTools.php
@@ -64,7 +64,8 @@ class TinkerTools {
 
     public function __construct(
         private readonly LoggerInterface $logger = new NullLogger(),
-    ) {}
+    ) {
+    }
 
     /**
      * Execute arbitrary PHP code within Craft's application context.
@@ -92,14 +93,16 @@ class TinkerTools {
             $this->logger->debug('Tinker executing', ['code' => mb_substr($code, 0, 200)]);
 
             foreach (self::BLOCKED_PATTERNS as $pattern) {
-                if (preg_match($pattern, $code)) {
-                    $this->logger->debug('Tinker blocked by security pattern', ['pattern' => $pattern]);
-
-                    return $this->response(
-                        $code,
-                        $this->formatError('SecurityError', 'Code contains blocked function. Shell commands, file writes, and eval are not allowed.'),
-                    );
+                if (!preg_match($pattern, $code)) {
+                    continue;
                 }
+
+                $this->logger->debug('Tinker blocked by security pattern', ['pattern' => $pattern]);
+
+                return $this->response(
+                    $code,
+                    $this->formatError('SecurityError', 'Code contains blocked function. Shell commands, file writes, and eval are not allowed.'),
+                );
             }
 
             try {

--- a/src/tools/TinkerTools.php
+++ b/src/tools/TinkerTools.php
@@ -10,6 +10,8 @@ use Mcp\Capability\Attribute\McpTool;
 use Mcp\Schema\Content\TextContent;
 use Mcp\Server\RequestContext;
 use ParseError;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Psy\CodeCleaner;
 use Psy\Exception\ParseErrorException;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
@@ -17,6 +19,7 @@ use stimmt\craft\Mcp\enums\OutputMode;
 use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\support\Ansi;
 use stimmt\craft\Mcp\support\MutexGuard;
+use stimmt\craft\Mcp\support\SafeExecution;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Throwable;
@@ -59,6 +62,10 @@ class TinkerTools {
 
     private ?CodeCleaner $cleaner = null;
 
+    public function __construct(
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {}
+
     /**
      * Execute arbitrary PHP code within Craft's application context.
      *
@@ -76,47 +83,56 @@ class TinkerTools {
         string $output = 'dump',
         ?RequestContext $context = null,
     ): TextContent {
-        // Note: SafeExecution is not used here because tinker has its own
-        // formatted error output for the REPL experience. Errors are part
-        // of the expected output, not SDK-level failures.
-        $outputMode = OutputMode::tryFrom($output) ?? OutputMode::DUMP;
+        // SafeExecution is the outer safety net for unexpected failures
+        // (e.g. CodeCleaner instantiation). The inner try/catch handles
+        // expected errors with REPL-style formatting.
+        return SafeExecution::run(function () use ($code, $output): TextContent {
+            $outputMode = OutputMode::tryFrom($output) ?? OutputMode::DUMP;
 
-        foreach (self::BLOCKED_PATTERNS as $pattern) {
-            if (preg_match($pattern, $code)) {
+            $this->logger->debug('Tinker executing', ['code' => mb_substr($code, 0, 200)]);
+
+            foreach (self::BLOCKED_PATTERNS as $pattern) {
+                if (preg_match($pattern, $code)) {
+                    $this->logger->debug('Tinker blocked by security pattern', ['pattern' => $pattern]);
+
+                    return $this->response(
+                        $code,
+                        $this->formatError('SecurityError', 'Code contains blocked function. Shell commands, file writes, and eval are not allowed.'),
+                    );
+                }
+            }
+
+            try {
+                $cleaner = $this->getCodeCleaner();
+                $cleanedCode = $cleaner->clean([$code]);
+
+                $app = Craft::$app;
+
+                ob_start();
+                $result = eval($cleanedCode);
+                $stdout = ob_get_clean();
+
+                $this->logger->debug('Tinker completed');
+
                 return $this->response(
                     $code,
-                    $this->formatError('SecurityError', 'Code contains blocked function. Shell commands, file writes, and eval are not allowed.'),
+                    $this->formatOutput($result, $outputMode),
+                    $stdout ?: null,
                 );
+            } catch (ParseErrorException|ParseError $e) {
+                ob_end_clean();
+                $this->logger->debug('Tinker caught error', ['error' => $e->getMessage()]);
+
+                return $this->response($code, $this->formatError('ParseError', $e->getMessage()));
+            } catch (Throwable $e) {
+                ob_end_clean();
+                $this->logger->debug('Tinker caught error', ['error' => $e->getMessage()]);
+
+                return $this->response($code, $this->formatError($e::class, $e->getMessage(), $e));
+            } finally {
+                MutexGuard::releaseAll();
             }
-        }
-
-        try {
-            $cleaner = $this->getCodeCleaner();
-            $cleanedCode = $cleaner->clean([$code]);
-
-            // Make useful variables available
-            $app = Craft::$app;
-
-            ob_start();
-            $result = eval($cleanedCode);
-            $stdout = ob_get_clean();
-
-            return $this->response(
-                $code,
-                $this->formatOutput($result, $outputMode),
-                $stdout ?: null,
-            );
-        } catch (ParseErrorException|ParseError $e) {
-            ob_end_clean();
-
-            return $this->response($code, $this->formatError('ParseError', $e->getMessage()));
-        } catch (Throwable $e) {
-            ob_end_clean();
-
-            return $this->response($code, $this->formatError($e::class, $e->getMessage(), $e));
-        } finally {
-            MutexGuard::releaseAll();
-        }
+        });
     }
 
     /**

--- a/src/tools/TinkerTools.php
+++ b/src/tools/TinkerTools.php
@@ -58,6 +58,9 @@ class TinkerTools {
         '/\bmove_uploaded_file\s*\(/i',
         '/\beval\s*\(/i',
         '/\bcreate_function\s*\(/i',
+        // Unbounded buffer teardown: the server's stdout shield buffer is
+        // non-removable, so a while-loop draining ob_get_level() never ends.
+        '/\bwhile\s*\(\s*ob_get_level\s*\(/i',
     ];
 
     private ?CodeCleaner $cleaner = null;
@@ -101,7 +104,7 @@ class TinkerTools {
 
                 return $this->response(
                     $code,
-                    $this->formatError('SecurityError', 'Code contains blocked function. Shell commands, file writes, and eval are not allowed.'),
+                    $this->formatError('SecurityError', 'Code contains a blocked pattern. Shell commands, file writes, eval, and unbounded output-buffer teardown loops are not allowed.'),
                 );
             }
 

--- a/tests/Unit/Support/FileLoggerTest.php
+++ b/tests/Unit/Support/FileLoggerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../Fixtures/CraftStub.php';
+
+use stimmt\craft\Mcp\support\FileLogger;
+
+beforeEach(function () {
+    $this->logPath = sys_get_temp_dir() . '/mcp-test-' . uniqid() . '.log';
+});
+
+afterEach(function () {
+    if (file_exists($this->logPath)) {
+        unlink($this->logPath);
+    }
+});
+
+describe('FileLogger', function () {
+    describe('log level filtering', function () {
+        it('writes messages at or above the minimum level', function () {
+            $logger = new FileLogger($this->logPath, 'warning');
+
+            $logger->error('an error');
+            $logger->warning('a warning');
+
+            $content = file_get_contents($this->logPath);
+            expect($content)
+                ->toContain('an error')
+                ->toContain('a warning');
+        });
+
+        it('suppresses messages below the minimum level', function () {
+            $logger = new FileLogger($this->logPath, 'error');
+
+            $logger->debug('debug noise');
+            $logger->info('info noise');
+            $logger->warning('warning noise');
+
+            expect(file_exists($this->logPath))->toBeFalse();
+        });
+
+        it('defaults to error level when no minimum specified', function () {
+            $logger = new FileLogger($this->logPath);
+
+            $logger->info('should be suppressed');
+
+            expect(file_exists($this->logPath))->toBeFalse();
+        });
+
+        it('writes error messages when using the default minimum level', function () {
+            $logger = new FileLogger($this->logPath);
+
+            $logger->error('an error gets through');
+
+            $content = file_get_contents($this->logPath);
+            expect($content)->toContain('an error gets through');
+        });
+
+        it('writes debug messages when minimum is debug', function () {
+            $logger = new FileLogger($this->logPath, 'debug');
+
+            $logger->debug('debug detail');
+
+            $content = file_get_contents($this->logPath);
+            expect($content)->toContain('debug detail');
+        });
+
+        it('treats unknown incoming log levels as warning priority (suppressed below error)', function () {
+            $logger = new FileLogger($this->logPath, 'error');
+
+            $logger->log('custom', 'custom message');
+
+            // 'custom' falls back to priority 3 (warning), which is below error (4)
+            expect(file_exists($this->logPath))->toBeFalse();
+        });
+
+        it('treats unknown incoming log levels as warning priority (written at or above warning)', function () {
+            $logger = new FileLogger($this->logPath, 'warning');
+
+            $logger->log('custom', 'custom message');
+
+            // 'custom' falls back to priority 3 (warning), which meets the warning (3) threshold
+            $content = file_get_contents($this->logPath);
+            expect($content)->toContain('custom message');
+        });
+
+        it('throws on invalid minimum level in constructor', function () {
+            expect(fn () => new FileLogger($this->logPath, 'invalid'))
+                ->toThrow(\InvalidArgumentException::class);
+        });
+    });
+});

--- a/tests/Unit/Tools/TinkerToolsTest.php
+++ b/tests/Unit/Tools/TinkerToolsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\tools\TinkerTools;
+
+describe('TinkerTools blocked patterns', function () {
+    it('blocks shell exec calls', function () {
+        $result = (new TinkerTools())->tinker("exec('ls');");
+
+        expect($result->text)->toContain('SecurityError');
+    });
+
+    it('blocks unbounded output buffer teardown loops', function (string $code) {
+        $result = (new TinkerTools())->tinker($code);
+
+        expect($result->text)->toContain('SecurityError');
+    })->with([
+        'spaced' => 'while (ob_get_level() > 0) { ob_end_clean(); }',
+        'compact' => 'while(ob_get_level()){ob_end_clean();}',
+        'negated comparison' => 'while (ob_get_level() !== 0) { ob_end_clean(); }',
+    ]);
+});


### PR DESCRIPTION
## Summary

Fixes #10. The tinker tool returned a generic "Tool execution failed" with zero detail when errors occurred outside its own try/catch (e.g., PsySH `CodeCleaner` instantiation failure). This happened because tinker was the only tool that skipped `SafeExecution::run()`, so unexpected errors hit the SDK's generic `\Throwable` handler which swallows the real message.

This PR adds three complementary improvements:

- **SafeExecution fallback for tinker**: Wraps tinker in `SafeExecution::run()` (consistent with every other tool). The inner try/catch still handles expected errors with REPL-style formatting. `SafeExecution` acts as an outer safety net so unexpected failures surface as `ToolCallException` with real error messages.
- **Configurable debug logging**: New `logLevel` config option (default: `'error'`) controls the verbosity of `storage/logs/mcp-server.log`. Set to `'debug'` to see full tool dispatch logging from the SDK, plus tinker-specific events (code being executed, security pattern blocks, caught errors).
- **Stdio transport shield**: stdout is the JSON-RPC stream, so any stray `echo`/`print` or PHP notice (from tinker'd code that closed the capture buffer, or Craft deprecations) corrupted the protocol framing and could hang the client. A non-removable output buffer in `bin/mcp-server` now reroutes all stray output to stderr. The transport is unaffected because it writes frames via `fwrite(STDOUT)`, which bypasses output buffering. Tinker additionally blocks unbounded `while (ob_get_level())` teardown loops, which would spin forever against the non-removable shield.

## Changes

| File | Change |
|------|--------|
| `src/tools/TinkerTools.php` | SafeExecution wrapper, LoggerInterface constructor injection, debug log calls, blocked pattern for unbounded output-buffer teardown loops |
| `src/support/FileLogger.php` | PSR-3 log level filtering with `LEVEL_PRIORITY` map, validated `$minLevel` constructor param |
| `src/models/Settings.php` | `logLevel` property with validation |
| `src/services/McpServerFactory.php` | `logLevel` param on `createFileLogger()` |
| `bin/mcp-server` | Stdout shield buffer, read `logLevel` setting, register logger + TinkerTools in DI container |
| `src/Mcp.php` | Rector 2.3.9 `NegatedAndsToPositiveOrsRector` (CI dependency drift, no behavior change) |
| `src/resources/SchemaResources.php`, `src/tools/GraphqlTools.php` | Dropped dead `??` fallbacks on properties Craft 5.10 types as non-nullable (CI dependency drift) |
| `tests/Unit/Support/FileLoggerTest.php` | 8 Pest tests for level filtering |
| `tests/Unit/Tools/TinkerToolsTest.php` | 4 Pest tests for blocked patterns |
| `docs/configuration.md` | `logLevel` in config reference, new Debugging section |
| `CHANGELOG.md` | Unreleased entries |

## Config example

```php
// config/mcp.php
return [
    'enabled' => true,
    'logLevel' => 'debug', // 'debug', 'info', 'warning', 'error' (default)
];
```

## Test plan

- [x] 159 tests pass (8 new for FileLogger, 4 new for TinkerTools blocked patterns, 0 regressions)
- [x] Tinker executes normally (`echo 'hello';` returns output)
- [x] Tinker error formatting preserved (REPL-style red error text)
- [x] Security blocking works (`exec('ls')` returns SecurityError)
- [x] End-to-end stdio verification against a live Craft install: scripted JSON-RPC session over stdin with raw stdout byte inspection. Confirmed clean framing for: normal execution, `ob_end_clean()` + throw (guard case), `ob_end_clean()` + `echo` (stray bytes rerouted to stderr), and unbounded teardown loop (blocked with SecurityError). Without the shield, the stray-echo case demonstrably corrupted the stream.
- [ ] Verify `logLevel => 'debug'` surfaces SDK + tinker debug logs after server restart
- [ ] Verify default `logLevel => 'error'` suppresses debug messages
