### PR TITLE
Self-heal stale project config: retry write tools once after StaleResourceException

### DIFF
--- a/src/support/PluginReloader.php
+++ b/src/support/PluginReloader.php
@@ -63,6 +63,20 @@ final class PluginReloader {
     }
 
     /**
+     * Re-read the project config from YAML.
+     *
+     * Clears the 'projectConfig:internal' cache and resets the ProjectConfig
+     * service so the next read/write picks up changes made by an external
+     * process (a CLI migration, `project-config/apply`, or a control-panel
+     * edit). This is what clears a `StaleResourceException` raised in the
+     * long-lived MCP server process.
+     */
+    public static function resetProjectConfig(): void {
+        self::clearProjectConfigCache();
+        Craft::$app->getProjectConfig()->reset();
+    }
+
+    /**
      * Reset the Plugins service to allow reloading.
      *
      * Clears all internal caches so loadPlugins() will re-read from database

--- a/src/support/SafeExecution.php
+++ b/src/support/SafeExecution.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace stimmt\craft\Mcp\support;
 
+use craft\errors\StaleResourceException;
 use Mcp\Exception\ToolCallException;
 use Throwable;
 
@@ -21,6 +22,13 @@ final class SafeExecution {
     /**
      * Execute a callable and convert any exceptions to ToolCallException.
      *
+     * The MCP server is a long-lived process that boots Craft once, so its
+     * loaded project config can go stale when an external process (a CLI
+     * migration, `project-config/apply`, or a control-panel edit) changes it.
+     * Write-path tools then throw a {@see StaleResourceException}. When that
+     * happens we re-read the project config from YAML and retry the operation
+     * ONCE, so callers don't have to reload the server by hand.
+     *
      * @template T
      * @param callable(): T $callback
      * @return T
@@ -31,12 +39,56 @@ final class SafeExecution {
             return $callback();
         } catch (ToolCallException $e) {
             throw $e;
+        } catch (StaleResourceException) {
+            self::recoverFromStaleProjectConfig();
+
+            return self::retry($callback);
         } catch (Throwable $e) {
-            throw new ToolCallException(
-                self::formatErrorMessage($e),
-                (int) $e->getCode(),
-                $e,
-            );
+            throw self::toToolCallException($e);
         }
+    }
+
+    /**
+     * Best-effort recovery from a stale project config.
+     *
+     * If the reset itself fails we still fall through to the retry, so the
+     * caller sees the operation's real outcome rather than a recovery-time
+     * error.
+     */
+    private static function recoverFromStaleProjectConfig(): void {
+        try {
+            PluginReloader::resetProjectConfig();
+        } catch (Throwable) {
+            // Intentionally ignored — fall through to the single retry below.
+        }
+    }
+
+    /**
+     * Re-run the callback after recovering from a stale project config.
+     *
+     * Only one retry is attempted; a still-failing call (including a persistent
+     * {@see StaleResourceException}) is surfaced as a ToolCallException.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     * @throws ToolCallException
+     */
+    private static function retry(callable $callback): mixed {
+        try {
+            return $callback();
+        } catch (ToolCallException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            throw self::toToolCallException($e);
+        }
+    }
+
+    private static function toToolCallException(Throwable $e): ToolCallException {
+        return new ToolCallException(
+            self::formatErrorMessage($e),
+            (int) $e->getCode(),
+            $e,
+        );
     }
 }

--- a/src/tools/McpTools.php
+++ b/src/tools/McpTools.php
@@ -136,19 +136,16 @@ class McpTools {
             // 2. Refresh Craft's composer plugin info cache (re-reads plugins.php)
             $refreshResult = PluginReloader::refreshComposerPluginInfo();
 
-            // 3. Clear project config cache (required before reset)
-            PluginReloader::clearProjectConfigCache();
+            // 3. Re-read project config from YAML (clears the internal cache first)
+            PluginReloader::resetProjectConfig();
 
-            // 4. Reset project config to re-read from YAML
-            Craft::$app->getProjectConfig()->reset();
-
-            // 5. Reset Plugins service internal caches
+            // 4. Reset Plugins service internal caches
             PluginReloader::resetPluginsService();
 
-            // 6. Reload Craft plugins
+            // 5. Reload Craft plugins
             Craft::$app->getPlugins()->loadPlugins();
 
-            // 7. Reset tool registry to re-collect tools
+            // 6. Reset tool registry to re-collect tools
             Mcp::resetToolRegistry();
 
             $summary = Mcp::getToolRegistry()->getSummary();

--- a/tests/Unit/Support/SafeExecutionTest.php
+++ b/tests/Unit/Support/SafeExecutionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use craft\errors\StaleResourceException;
+use Mcp\Exception\ToolCallException;
+use stimmt\craft\Mcp\support\SafeExecution;
+
+describe('SafeExecution::run()', function () {
+    it('returns the callback result on success', function () {
+        expect(SafeExecution::run(fn (): int => 42))->toBe(42);
+    });
+
+    it('rethrows a ToolCallException unchanged', function () {
+        $original = new ToolCallException('boom');
+
+        try {
+            SafeExecution::run(function () use ($original): never {
+                throw $original;
+            });
+            $this->fail('Expected the ToolCallException to be rethrown.');
+        } catch (ToolCallException $e) {
+            expect($e)->toBe($original);
+        }
+    });
+
+    it('wraps a generic throwable as a ToolCallException', function () {
+        $cause = new RuntimeException('kaboom');
+
+        try {
+            SafeExecution::run(function () use ($cause): never {
+                throw $cause;
+            });
+            $this->fail('Expected a ToolCallException to be thrown.');
+        } catch (ToolCallException $e) {
+            expect($e->getPrevious())->toBe($cause);
+        }
+    });
+
+    it('recovers from a stale project config and retries once', function () {
+        $attempts = 0;
+
+        $result = SafeExecution::run(function () use (&$attempts): string {
+            $attempts++;
+            if ($attempts === 1) {
+                throw new StaleResourceException('The loaded project config is out-of-date.');
+            }
+
+            return 'recovered';
+        });
+
+        expect($result)->toBe('recovered')
+            ->and($attempts)->toBe(2);
+    });
+
+    it('surfaces a persistent stale project config as a ToolCallException after one retry', function () {
+        $attempts = 0;
+        $stale = new StaleResourceException('The loaded project config is out-of-date.');
+
+        try {
+            SafeExecution::run(function () use (&$attempts, $stale): never {
+                $attempts++;
+
+                throw $stale;
+            });
+            $this->fail('Expected a ToolCallException to be thrown.');
+        } catch (ToolCallException $e) {
+            expect($e->getPrevious())->toBe($stale)
+                ->and($attempts)->toBe(2);
+        }
+    });
+});


### PR DESCRIPTION
## Problem

The MCP server (`bin/mcp-server`) boots Craft **once** and serves every request from that single long-lived application instance. So its in-memory project config goes **stale** the moment an external process — a CLI migration, `project-config/apply`, or a control-panel edit — changes it. The next write-path tool call (e.g. `tinker` running `saveEntryType`/`saveField`, `create_entry`, `update_entry`) then fails with:

```
StaleResourceException: The loaded project config is out-of-date.
```

Today the only recovery is to manually call `reload_mcp` (or reconnect the server). In a normal dev loop — run a migration in the terminal, then ask the assistant to inspect/modify entries — this happens constantly and is easy to mistake for a real failure.

## Fix

`SafeExecution::run()` (which already wraps every tool) now recovers automatically: on a `StaleResourceException` it re-reads the project config from YAML and **retries the operation once**. Recovery is best-effort — if the reset itself throws, we still fall through to the retry so the caller sees the operation's real outcome rather than a recovery-time error. A persistent staleness is still surfaced as a `ToolCallException`, exactly as before.

- Add `PluginReloader::resetProjectConfig()` — clears the `projectConfig:internal` cache then calls `ProjectConfig::reset()`. `reload_mcp` now reuses this instead of inlining the same two steps (single source of truth; no behavior change there).
- `SafeExecution::run()` catches `StaleResourceException`, recovers, and retries once.
- Read-path tools are unaffected (they never throw it).

## Tests

- New `tests/Unit/Support/SafeExecutionTest.php` covering: success passthrough, `ToolCallException` re-throw, generic-throwable wrapping, **recover-and-retry**, and **persistent-failure → ToolCallException**.
- Full suite green: **152 passed**. `pint` clean on the changed files.
- `phpstan`: the changed files are clean. (There are 2 `nullCoalesce.property` errors in `resources/SchemaResources.php` and `tools/GraphqlTools.php` — these are **pre-existing on `master`**, unrelated to this PR, and appear to stem from a craftcms/cms nullability change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)