### PR TITLE
fix: tinker output buffer drain baseline and psysh requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tinker` tool now wraps execution in `SafeExecution`, ensuring unexpected errors surface with real messages instead of the generic "Tool execution failed" ([#10](https://github.com/stimmtdigital/craft-mcp/issues/10))
 - Stray output (echo/print/PHP notices from tinker'd code or Craft) no longer corrupts the stdio JSON-RPC stream; it is rerouted to stderr via a non-removable output buffer in `bin/mcp-server`
 - `tinker` tool blocks unbounded `while (ob_get_level())` teardown loops, which would spin forever against the non-removable stdout shield
+- `tinker` tool now drains only output buffers it opened (baseline-aware): the previous `ob_get_level() > 0` guard closed outer buffers such as the stdout shield, clobbering the original error with an `ErrorException` when user code had closed the capture buffer
+- Added explicit `psy/psysh` requirement: tinker relied on it arriving transitively (e.g. via `yiisoft/yii2-shell`) and fatally errored on installs without it
 
 ## [1.2.2] - 2026-03-04
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require": {
         "php": "^8.3",
         "craftcms/cms": "^5.0",
-        "mcp/sdk": "^0.4"
+        "mcp/sdk": "^0.4",
+        "psy/psysh": "^0.12"
     },
     "require-dev": {
         "laravel/pint": "^1.18",

--- a/src/tools/TinkerTools.php
+++ b/src/tools/TinkerTools.php
@@ -108,6 +108,8 @@ class TinkerTools {
                 );
             }
 
+            $baseLevel = ob_get_level();
+
             try {
                 $cleaner = $this->getCodeCleaner();
                 $cleanedCode = $cleaner->clean([$code]);
@@ -116,27 +118,23 @@ class TinkerTools {
 
                 ob_start();
                 $result = eval($cleanedCode);
-                $stdout = ob_get_clean();
+                $stdout = $this->drainCapturedOutput($baseLevel);
 
                 $this->logger->debug('Tinker completed');
 
                 return $this->response(
                     $code,
                     $this->formatOutput($result, $outputMode),
-                    $stdout ?: null,
+                    $stdout,
                 );
             } catch (ParseErrorException|ParseError $e) {
-                if (ob_get_level() > 0) {
-                    ob_end_clean();
-                }
+                $this->drainCapturedOutput($baseLevel);
 
                 $this->logger->debug('Tinker caught error', ['error' => $e->getMessage()]);
 
                 return $this->response($code, $this->formatError('ParseError', $e->getMessage()));
             } catch (Throwable $e) {
-                if (ob_get_level() > 0) {
-                    ob_end_clean();
-                }
+                $this->drainCapturedOutput($baseLevel);
 
                 $this->logger->debug('Tinker caught error', ['error' => $e->getMessage()]);
 
@@ -145,6 +143,30 @@ class TinkerTools {
                 MutexGuard::releaseAll();
             }
         });
+    }
+
+    /**
+     * Collect and close every buffer opened above the capture baseline.
+     *
+     * User code may have closed the capture buffer or opened extra ones,
+     * so this only drains buffers above $baseLevel. Outer buffers such as
+     * the stdout shield in bin/mcp-server are never touched, and a
+     * non-removable buffer above the baseline stops the drain instead of
+     * looping forever.
+     */
+    private function drainCapturedOutput(int $baseLevel): ?string {
+        $stdout = '';
+
+        while (ob_get_level() > $baseLevel) {
+            $flags = (int) (ob_get_status()['flags'] ?? 0);
+            if (($flags & PHP_OUTPUT_HANDLER_REMOVABLE) === 0) {
+                break;
+            }
+
+            $stdout = ob_get_clean() . $stdout;
+        }
+
+        return $stdout !== '' ? $stdout : null;
     }
 
     /**

--- a/tests/Unit/Tools/TinkerToolsTest.php
+++ b/tests/Unit/Tools/TinkerToolsTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../../Fixtures/CraftStub.php';
+
+use stimmt\craft\Mcp\Tests\Fixtures\TestMutex;
 use stimmt\craft\Mcp\tools\TinkerTools;
 
 describe('TinkerTools blocked patterns', function () {
@@ -20,4 +23,88 @@ describe('TinkerTools blocked patterns', function () {
         'compact' => 'while(ob_get_level()){ob_end_clean();}',
         'negated comparison' => 'while (ob_get_level() !== 0) { ob_end_clean(); }',
     ]);
+});
+
+describe('TinkerTools output buffer handling', function () {
+    beforeEach(function () {
+        $this->originalApp = Craft::$app;
+        $mutex = new TestMutex();
+        $projectConfig = new class () {
+            private bool $_locked = false;
+
+            public function setLocked(bool $value): void {
+                $this->_locked = $value;
+            }
+
+            public function isLocked(): bool {
+                return $this->_locked;
+            }
+        };
+
+        Craft::$app = new class ($mutex, $projectConfig) {
+            public function __construct(
+                private readonly object $mutex,
+                private readonly object $projectConfig,
+            ) {
+            }
+
+            public function getMutex(): object {
+                return $this->mutex;
+            }
+
+            public function getProjectConfig(): object {
+                return $this->projectConfig;
+            }
+        };
+    });
+
+    afterEach(function () {
+        Craft::$app = $this->originalApp;
+    });
+
+    it('captures echoed output', function () {
+        $result = (new TinkerTools())->tinker("echo 'hello-stdout'; return 1;");
+
+        expect($result->text)->toContain('hello-stdout');
+    });
+
+    it('preserves outer buffers when user code closes the capture buffer', function () {
+        ob_start();
+        $level = ob_get_level();
+
+        $result = (new TinkerTools())->tinker("ob_end_clean(); return 'done';");
+
+        $intact = ob_get_level() === $level;
+        if ($intact) {
+            ob_end_clean();
+        }
+
+        expect($intact)->toBeTrue()
+            ->and($result->text)->toContain('done');
+    });
+
+    it('keeps the original error when user code closes the capture buffer and throws', function () {
+        ob_start();
+        $level = ob_get_level();
+
+        $result = (new TinkerTools())->tinker("ob_end_clean(); throw new RuntimeException('original-error');");
+
+        $intact = ob_get_level() === $level;
+        if ($intact) {
+            ob_end_clean();
+        }
+
+        expect($intact)->toBeTrue()
+            ->and($result->text)->toContain('original-error');
+    });
+
+    it('closes extra buffers opened by user code', function () {
+        $level = ob_get_level();
+
+        $result = (new TinkerTools())->tinker("ob_start(); echo 'inner'; return 'done';");
+
+        expect(ob_get_level())->toBe($level)
+            ->and($result->text)->toContain('done')
+            ->and($result->text)->toContain('inner');
+    });
 });


### PR DESCRIPTION
## Summary

Follow-up to #11. Live testing of the stdout shield surfaced a regression in tinker's buffer cleanup, plus a latent missing dependency.

- **Buffer drain against a baseline**: the catch-path guard from #11 closed any buffer while `ob_get_level() > 0`. With the stdout shield installed, level is always at least 1, so after user code closed tinker's capture buffer the guard tried to close the non-removable shield. Yii's error handler converts the resulting warning into an `ErrorException` that replaced the original error in the tool response. The same flaw could consume an unrelated outer buffer in any context (web request, test runner). Tinker now records the buffer level before `ob_start()` and drains only buffers above that baseline: it collects output from extra buffers user code opened, skips outer buffers entirely, and stops at non-removable ones instead of looping.
- **Explicit `psy/psysh` requirement**: `TinkerTools` instantiates `Psy\CodeCleaner`, but the package only arrived transitively (in our playground via `yiisoft/yii2-shell`). On installs without such a package every tinker call fatally errored.

## Test plan

- [x] 163 tests pass (4 new: outer-buffer preservation on return and on throw, extra-buffer drain, echo capture)
- [x] End-to-end stdio harness against a live Craft install: `ob_end_clean(); throw` now returns the original error (previously clobbered by `ErrorException: ob_end_clean(): Failed to discard buffer`), extra user buffers drain into the tool response, stray echo still reroutes to stderr, JSON-RPC framing stays clean
- [x] PHPStan, Rector, and Pint clean
