### PR TITLE
build: upgrade mcp/sdk to ^0.6 with explicit symfony/finder requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tinker` tool now drains only output buffers it opened (baseline-aware): the previous `ob_get_level() > 0` guard closed outer buffers such as the stdout shield, clobbering the original error with an `ErrorException` when user code had closed the capture buffer
 - Added explicit `psy/psysh` requirement: tinker relied on it arriving transitively (e.g. via `yiisoft/yii2-shell`) and fatally errored on installs without it
 
+### Changed
+- Upgraded `mcp/sdk` from `^0.4` to `^0.6`
+- Added explicit `symfony/finder` requirement: the SDK moved it from `require` to `suggest` in 0.5, but file-based discovery (used for tool/prompt/resource registration) still needs it at server boot
+
 ## [1.2.2] - 2026-03-04
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,9 @@
     "require": {
         "php": "^8.3",
         "craftcms/cms": "^5.0",
-        "mcp/sdk": "^0.4",
-        "psy/psysh": "^0.12"
+        "mcp/sdk": "^0.6",
+        "psy/psysh": "^0.12",
+        "symfony/finder": "^6.4 || ^7.3 || ^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",


### PR DESCRIPTION
## Summary

Upgrades `mcp/sdk` from `^0.4` to `^0.6`. Supersedes #19: Dependabot's constraint-only bump would break production installs, because the SDK moved `symfony/finder` from `require` to `suggest` in 0.5 while file-based discovery (which registers all tools, prompts, and resources) still needs it at server boot. Without it, `Discoverer::__construct()` throws a `RuntimeException` and the server never starts. This PR adds the explicit `symfony/finder` requirement alongside the bump.

## Compatibility review against the 0.5/0.6 BC breaks

- `Mcp\Schema\Resource` renamed to `ResourceDefinition`: not referenced anywhere in the plugin
- `ArrayLoader` renamed, `RegistryInterface` method changes: not used
- `$title` parameter inserted into `Builder::addTool()/addPrompt()/addResource()/addResourceTemplate()` signatures: all call sites already use named arguments
- `StreamableHttpTransport` CORS changes: plugin uses stdio transport only
- Default protocol version bumped to `2025-11-25`: negotiation verified live

## Test plan

- [x] 163 tests pass on SDK 0.6
- [x] PHPStan, Rector, and Pint clean
- [x] End-to-end stdio session against a live Craft install on SDK 0.6: initialize negotiates protocol `2025-11-25`, discovery registers tools (proving the Finder path), tinker executes normally, error and security-block responses intact, stdout shield and buffer handling behave identically to 0.4
