### PR TITLE
fix: harden tool audit findings (SQL guard, deprecations, null/false guards, deps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `list_asset_folders` no longer dereferences a null root folder when a volume has no indexed root folder
 - `list_backups` and `create_backup` guard against `filesize()`/`filemtime()` returning `false` (file removed mid-listing), preventing a `TypeError`
 - Added explicit `symfony/polyfill-php84` requirement: `array_any()` (PHP 8.4) is used on the supported `^8.3` floor and previously relied on the polyfill arriving transitively
+- `list_event_handlers` reported class-level handlers with the `class` and `event` fields swapped; Yii stores them as `$_events[eventName][className]`, so the two nesting levels were mislabeled
 
 ### Changed
 - Extracted read-only SQL validation into a shared `SqlReadGuard` support class used by `run_query` and `explain_query`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tinker` tool blocks unbounded `while (ob_get_level())` teardown loops, which would spin forever against the non-removable stdout shield
 - `tinker` tool now drains only output buffers it opened (baseline-aware): the previous `ob_get_level() > 0` guard closed outer buffers such as the stdout shield, clobbering the original error with an `ErrorException` when user code had closed the capture buffer
 - Added explicit `psy/psysh` requirement: tinker relied on it arriving transitively (e.g. via `yiisoft/yii2-shell`) and fatally errored on installs without it
+- `run_query` and `explain_query` no longer reject legitimate SELECTs whose columns contain a blocked keyword as a substring (e.g. `dateCreated` matched `CREATE`, `dateUpdated` matched `UPDATE`); the read-only guard now matches keywords on word boundaries via the shared `SqlReadGuard`, and `explain_query` gained the stronger keyword set
+- `get_deprecations` database lookup selected a nonexistent `template` column, so the query always failed and was silently swallowed; the column is removed and the query now runs
+- `get_table_counts` and `get_deprecations` check table existence via schema instead of catching every `Throwable`, so a genuine database error surfaces instead of being masked as "Table not found" / zero results
+- `list_asset_folders` no longer dereferences a null root folder when a volume has no indexed root folder
+- `list_backups` and `create_backup` guard against `filesize()`/`filemtime()` returning `false` (file removed mid-listing), preventing a `TypeError`
+- Added explicit `symfony/polyfill-php84` requirement: `array_any()` (PHP 8.4) is used on the supported `^8.3` floor and previously relied on the polyfill arriving transitively
 
 ### Changed
+- Extracted read-only SQL validation into a shared `SqlReadGuard` support class used by `run_query` and `explain_query`
 - Upgraded `mcp/sdk` from `^0.4` to `^0.6`
 - Added explicit `symfony/finder` requirement: the SDK moved it from `require` to `suggest` in 0.5, but file-based discovery (used for tool/prompt/resource registration) still needs it at server boot
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "craftcms/cms": "^5.0",
         "mcp/sdk": "^0.6",
         "psy/psysh": "^0.12",
-        "symfony/finder": "^6.4 || ^7.3 || ^8.0"
+        "symfony/finder": "^6.4 || ^7.3 || ^8.0",
+        "symfony/polyfill-php84": "^1.31"
     },
     "require-dev": {
         "laravel/pint": "^1.18",

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\Config\RectorConfig;
+use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\Set\ValueObject\SetList;
 
 return RectorConfig::configure()
@@ -26,6 +27,11 @@ return RectorConfig::configure()
         // Skip overly aggressive rules
         ExplicitBoolCompareRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,
+
+        // Keep @deprecated as documentation only. The #[\Deprecated] attribute
+        // emits runtime E_USER_DEPRECATED notices, which would spam logs for
+        // still-internally-used members like Mcp::DANGEROUS_TOOLS.
+        DeprecatedAnnotationToDeprecatedAttributeRector::class,
     ])
     ->withImportNames(
         importShortClasses: false,

--- a/src/console/controllers/InstallController.php
+++ b/src/console/controllers/InstallController.php
@@ -231,13 +231,7 @@ class InstallController extends Controller {
      * @param McpClientInterface[] $clients
      */
     private function anyClientRequiresAbsolutePaths(array $clients): bool {
-        foreach ($clients as $client) {
-            if ($client->requiresAbsolutePaths()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($clients, fn ($client) => $client->requiresAbsolutePaths());
     }
 
     /**

--- a/src/installer/ProjectRootResolver.php
+++ b/src/installer/ProjectRootResolver.php
@@ -70,12 +70,6 @@ final readonly class ProjectRootResolver {
     }
 
     private function hasMarker(string $directory): bool {
-        foreach (self::MARKERS as $marker) {
-            if (is_dir($directory . DIRECTORY_SEPARATOR . $marker)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(self::MARKERS, fn ($marker) => is_dir($directory . DIRECTORY_SEPARATOR . $marker));
     }
 }

--- a/src/support/SqlReadGuard.php
+++ b/src/support/SqlReadGuard.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Mcp\Exception\ToolCallException;
+
+/**
+ * Basic read-only guard for user-supplied SQL.
+ *
+ * WARNING: keyword-based, not a real sandbox. It can be bypassed (comments,
+ * multi-statement queries if the PDO driver allows them). It exists to stop
+ * obvious writes in a development tool, not to make arbitrary SQL safe.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class SqlReadGuard {
+    /**
+     * Write/DDL keywords rejected anywhere in the query.
+     */
+    private const array BLOCKED_KEYWORDS = [
+        'INSERT', 'UPDATE', 'DELETE', 'DROP', 'TRUNCATE',
+        'ALTER', 'CREATE', 'GRANT', 'REVOKE', 'INTO OUTFILE',
+    ];
+
+    /**
+     * Assert the query is a read-only SELECT and return it trimmed.
+     *
+     * Keywords are matched on word boundaries so column names that merely
+     * contain a keyword as a substring (e.g. `dateCreated`, `dateUpdated`)
+     * are not falsely rejected.
+     *
+     * @throws ToolCallException if the query is not a bare SELECT or contains a blocked keyword
+     */
+    public static function assertSelectOnly(string $sql): string {
+        $trimmed = trim($sql);
+
+        if (!preg_match('/^SELECT\b/i', $trimmed)) {
+            throw new ToolCallException('Only SELECT queries are allowed for safety.');
+        }
+
+        foreach (self::BLOCKED_KEYWORDS as $keyword) {
+            if (preg_match('/\b' . preg_quote($keyword, '/') . '\b/i', $trimmed)) {
+                throw new ToolCallException("Query contains blocked keyword: {$keyword}");
+            }
+        }
+
+        return $trimmed;
+    }
+}

--- a/src/tools/AssetTools.php
+++ b/src/tools/AssetTools.php
@@ -190,6 +190,9 @@ class AssetTools {
         }
 
         $rootFolder = $assetsService->getRootFolderByVolumeId($volumeModel->id);
+        if ($rootFolder === null) {
+            return [];
+        }
 
         return $assetsService->findFolders(['parentId' => $rootFolder->id]);
     }

--- a/src/tools/BackupTools.php
+++ b/src/tools/BackupTools.php
@@ -42,9 +42,17 @@ class BackupTools {
             $backups = [];
 
             foreach ($files as $file) {
-                $filename = basename($file);
                 $size = filesize($file);
                 $modified = filemtime($file);
+                // Skip files that vanished between glob() and stat (cleanup race).
+                if ($size === false) {
+                    continue;
+                }
+                if ($modified === false) {
+                    continue;
+                }
+
+                $filename = basename($file);
 
                 $backups[] = [
                     'filename' => $filename,
@@ -92,6 +100,9 @@ class BackupTools {
 
             $filename = basename($backupPath);
             $size = file_exists($backupPath) ? filesize($backupPath) : 0;
+            if ($size === false) {
+                $size = 0;
+            }
 
             return [
                 'success' => true,

--- a/src/tools/CraftTools.php
+++ b/src/tools/CraftTools.php
@@ -117,7 +117,7 @@ class CraftTools {
                 'craft' => [
                     'version' => Craft::$app->getVersion(),
                     'edition' => Craft::$app->getEditionName(),
-                    'schemaVersion' => $info->schemaVersion ?? null,
+                    'schemaVersion' => $info->schemaVersion,
                     'environment' => Craft::$app->env ?? 'production',
                     'devMode' => Craft::$app->getConfig()->getGeneral()->devMode,
                 ],

--- a/src/tools/DatabaseTools.php
+++ b/src/tools/DatabaseTools.php
@@ -12,6 +12,7 @@ use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
+use stimmt\craft\Mcp\support\SqlReadGuard;
 use Throwable;
 
 /**
@@ -118,11 +119,6 @@ class DatabaseTools {
     /**
      * Blocked SQL keywords.
      */
-    private const array BLOCKED_SQL_KEYWORDS = [
-        'INSERT', 'UPDATE', 'DELETE', 'DROP', 'TRUNCATE',
-        'ALTER', 'CREATE', 'GRANT', 'REVOKE', 'INTO OUTFILE',
-    ];
-
     /**
      * Execute a read-only SQL query.
      *
@@ -138,21 +134,10 @@ class DatabaseTools {
         return SafeExecution::run(function () use ($sql, $limit, $context): array {
             $context?->getClientGateway()?->progress(0, 2, 'Executing SQL query...');
 
-            $trimmedSql = trim($sql);
-            $upperSql = strtoupper($trimmedSql);
-
-            if (!str_starts_with($upperSql, 'SELECT')) {
-                throw new ToolCallException('Only SELECT queries are allowed for safety.');
-            }
-
-            foreach (self::BLOCKED_SQL_KEYWORDS as $keyword) {
-                if (str_contains($upperSql, $keyword)) {
-                    throw new ToolCallException("Query contains blocked keyword: {$keyword}");
-                }
-            }
+            $trimmedSql = SqlReadGuard::assertSelectOnly($sql);
 
             // Add LIMIT if not present
-            if (!str_contains($upperSql, 'LIMIT')) {
+            if (!preg_match('/\bLIMIT\b/i', $trimmedSql)) {
                 $sql = rtrim($trimmedSql, ';') . " LIMIT {$limit}";
             }
 
@@ -225,21 +210,25 @@ class DatabaseTools {
 
             $counts = [];
             foreach ($tables as $table => $label) {
-                try {
-                    $fullTable = $prefix . $table;
-                    $count = $db->createCommand("SELECT COUNT(*) FROM `{$fullTable}`")->queryScalar();
-                    $counts[$table] = [
-                        'label' => $label,
-                        'count' => (int) $count,
-                    ];
-                } catch (Throwable) {
-                    // Table might not exist
+                $fullTable = $prefix . $table;
+
+                // Skip tables that genuinely don't exist; let real query
+                // failures surface via SafeExecution instead of masking them.
+                if ($db->getTableSchema($fullTable) === null) {
                     $counts[$table] = [
                         'label' => $label,
                         'count' => null,
-                        'error' => 'Table not found',
+                        'error' => 'Table does not exist',
                     ];
+
+                    continue;
                 }
+
+                $count = $db->createCommand("SELECT COUNT(*) FROM `{$fullTable}`")->queryScalar();
+                $counts[$table] = [
+                    'label' => $label,
+                    'count' => (int) $count,
+                ];
             }
 
             return $counts;

--- a/src/tools/DebugTools.php
+++ b/src/tools/DebugTools.php
@@ -413,11 +413,14 @@ class DebugTools {
     /**
      * Flatten nested class events structure.
      *
+     * Yii stores class-level handlers as `Event::$_events[$eventName][$className][]`,
+     * so the outer key is the event name and the inner key is the class name.
+     *
      * @return Generator<array{class: string, event: string, count: int, handlers: array}>
      */
     private function flattenClassEvents(array $classEventsProperty, ?string $filter): Generator {
         $flattened = array_merge(...array_map(
-            fn (string $className, array $classEventHandlers) => $this->extractClassEvents($className, $classEventHandlers, $filter),
+            fn (string $eventName, array $classHandlers) => $this->extractClassEvents($eventName, $classHandlers, $filter),
             array_keys($classEventsProperty),
             array_values($classEventsProperty),
         ));
@@ -426,15 +429,15 @@ class DebugTools {
     }
 
     /**
-     * Extract events for a single class.
+     * Extract the per-class handlers registered for a single event name.
      *
-     * @param array<string, array> $classEventHandlers
+     * @param array<string, array> $classHandlers keyed by class name
      * @return array<array{class: string, event: string, count: int, handlers: array}>
      */
-    private function extractClassEvents(string $className, array $classEventHandlers, ?string $filter): array {
+    private function extractClassEvents(string $eventName, array $classHandlers, ?string $filter): array {
         return array_filter(
             array_map(
-                fn (string $eventName, array $eventHandlerList) => $this->matchesFilter($className, $eventName, $filter)
+                fn (string $className, array $eventHandlerList) => $this->matchesFilter($className, $eventName, $filter)
                     ? [
                         'class' => $className,
                         'event' => $eventName,
@@ -442,8 +445,8 @@ class DebugTools {
                         'handlers' => $this->describeHandlers($eventHandlerList),
                     ]
                     : null,
-                array_keys($classEventHandlers),
-                array_values($classEventHandlers),
+                array_keys($classHandlers),
+                array_values($classHandlers),
             ),
         );
     }

--- a/src/tools/DebugTools.php
+++ b/src/tools/DebugTools.php
@@ -16,6 +16,7 @@ use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\support\FileHelper;
 use stimmt\craft\Mcp\support\SafeExecution;
+use stimmt\craft\Mcp\support\SqlReadGuard;
 use Throwable;
 use yii\base\Event;
 
@@ -190,14 +191,16 @@ class DebugTools {
                 }
             }
 
-            // Also check deprecation errors table if it exists
-            try {
-                $db = Craft::$app->getDb();
-                $prefix = $db->tablePrefix;
-                $table = $prefix . 'deprecationerrors';
+            // Also check the deprecation errors table if it exists. Guard on
+            // table existence rather than catching everything, so a genuine
+            // query failure surfaces instead of silently reporting zero.
+            $dbDeprecations = [];
+            $db = Craft::$app->getDb();
+            $table = $db->tablePrefix . 'deprecationerrors';
 
+            if ($db->getTableSchema($table) !== null) {
                 $dbDeprecations = $db->createCommand(
-                    "SELECT id, `key`, fingerprint, lastOccurrence, file, line, message, template
+                    "SELECT id, `key`, fingerprint, lastOccurrence, file, line, message
                      FROM `{$table}`
                      ORDER BY lastOccurrence DESC
                      LIMIT {$limit}",
@@ -208,8 +211,8 @@ class DebugTools {
                         $dep['lastOccurrence'] = date('Y-m-d H:i:s', strtotime((string) $dep['lastOccurrence']));
                     }
                 }
-            } catch (Throwable) {
-                $dbDeprecations = [];
+
+                unset($dep);
             }
 
             // Limit and dedupe log deprecations
@@ -239,21 +242,8 @@ class DebugTools {
     #[McpToolMeta(category: ToolCategory::DEBUGGING)]
     public function explainQuery(string $sql, ?RequestContext $context = null): array {
         return SafeExecution::run(function () use ($sql): array {
-            // Security: Only allow SELECT queries
-            $trimmedSql = trim($sql);
-            $upperSql = strtoupper($trimmedSql);
-
-            if (!str_starts_with($upperSql, 'SELECT')) {
-                throw new ToolCallException('Only SELECT queries can be explained');
-            }
-
-            // Block dangerous keywords
-            $blockedKeywords = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'TRUNCATE', 'ALTER', 'CREATE'];
-            foreach ($blockedKeywords as $keyword) {
-                if (str_contains($upperSql, $keyword)) {
-                    throw new ToolCallException("Query contains blocked keyword: {$keyword}");
-                }
-            }
+            // Security: only allow read-only SELECT queries
+            $trimmedSql = SqlReadGuard::assertSelectOnly($sql);
 
             $db = Craft::$app->getDb();
             $driver = $db->getDriverName();

--- a/src/tools/GraphqlTools.php
+++ b/src/tools/GraphqlTools.php
@@ -84,8 +84,7 @@ class GraphqlTools {
             $sdl = null;
 
             try {
-                $schemaDef = $gql->getSchemaDef($schema);
-                $sdl = $schemaDef !== null ? (string) $schemaDef : null;
+                $sdl = (string) $gql->getSchemaDef($schema);
             } catch (Throwable) {
                 // SDL generation might fail for some schemas
             }

--- a/tests/Unit/Support/SqlReadGuardTest.php
+++ b/tests/Unit/Support/SqlReadGuardTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Mcp\Exception\ToolCallException;
+use stimmt\craft\Mcp\support\SqlReadGuard;
+
+describe('SqlReadGuard::assertSelectOnly()', function () {
+    it('returns the trimmed query for a plain SELECT', function () {
+        expect(SqlReadGuard::assertSelectOnly('  SELECT id FROM entries  '))
+            ->toBe('SELECT id FROM entries');
+    });
+
+    it('allows columns whose names contain a blocked keyword as a substring', function (string $sql) {
+        expect(SqlReadGuard::assertSelectOnly($sql))->toBe(trim($sql));
+    })->with([
+        'dateCreated (CREATE)' => 'SELECT dateCreated FROM entries',
+        'dateUpdated (UPDATE)' => 'SELECT dateUpdated, title FROM entries',
+        'both' => 'SELECT dateCreated, dateUpdated FROM elements',
+    ]);
+
+    it('blocks a query that is not a SELECT', function (string $sql) {
+        expect(fn () => SqlReadGuard::assertSelectOnly($sql))
+            ->toThrow(ToolCallException::class);
+    })->with([
+        'update' => 'UPDATE entries SET title = "x"',
+        'delete' => 'DELETE FROM entries',
+        'insert' => 'INSERT INTO entries (title) VALUES ("x")',
+        'empty' => '',
+    ]);
+
+    it('blocks a SELECT that contains a real write keyword as a token', function (string $sql) {
+        expect(fn () => SqlReadGuard::assertSelectOnly($sql))
+            ->toThrow(ToolCallException::class);
+    })->with([
+        'create table via subquery' => 'SELECT 1; CREATE TABLE t (id int)',
+        'drop' => 'SELECT 1; DROP TABLE entries',
+        'delete' => 'SELECT 1; DELETE FROM entries',
+        'into outfile' => 'SELECT * FROM entries INTO OUTFILE "/tmp/x"',
+        'grant' => 'SELECT 1; GRANT ALL ON *.* TO x',
+    ]);
+});

--- a/tests/Unit/Tools/DebugToolsTest.php
+++ b/tests/Unit/Tools/DebugToolsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../Fixtures/CraftStub.php';
+
+use stimmt\craft\Mcp\tools\DebugTools;
+use yii\base\Event;
+
+describe('DebugTools::listEventHandlers() class events', function () {
+    afterEach(function () {
+        Event::off('Acme\\Widget', 'onFrobnicate');
+    });
+
+    it('labels class-level handlers with the real class and event, not swapped', function () {
+        Event::on('Acme\\Widget', 'onFrobnicate', fn () => null);
+
+        $result = (new DebugTools())->listEventHandlers('onFrobnicate');
+        $events = $result['classEvents']['events'];
+
+        expect($events)->toHaveKey('Acme\\Widget::onFrobnicate')
+            ->and($events['Acme\\Widget::onFrobnicate']['class'])->toBe('Acme\\Widget')
+            ->and($events['Acme\\Widget::onFrobnicate']['event'])->toBe('onFrobnicate')
+            ->and($events['Acme\\Widget::onFrobnicate']['count'])->toBe(1);
+    });
+});


### PR DESCRIPTION
Closes #12.

## Summary

Ran a live runtime smoke test of all 50 MCP tools against a real Craft install (driving the server over stdio and inspecting responses), plus a targeted source review, to find the class of bugs that unit tests miss (unit tests stub Craft; there is no integration test hitting a real DB). All 50 tools are green after these fixes; the only remaining "failures" in the smoke test are the 4 Commerce tools reporting "Commerce not installed", which is correct on a site without Commerce.

## Fixes

- **`run_query` / `explain_query` blocked legitimate SELECTs.** The read-only write-guard used `str_contains(upperSql, 'CREATE')` / `'UPDATE'`, which match the substrings in `dateCreated` / `dateUpdated`, columns on nearly every Craft table. `SELECT dateCreated FROM entries` was rejected as "blocked keyword: CREATE". Extracted a shared `SqlReadGuard` that matches keywords on word boundaries; `explain_query` now uses the full keyword set (it was missing `GRANT`/`REVOKE`/`INTO OUTFILE`). Verified live: `dateCreated`/`dateUpdated` selects now run; `UPDATE`/`DROP`/`INTO OUTFILE` are still blocked.
- **`get_deprecations` DB lookup never worked.** It selected a nonexistent `template` column from `deprecationerrors`, so the query always threw and was silently swallowed by a broad `catch (Throwable)`. Removed the column; the query now runs.
- **Stop masking real DB errors.** `get_table_counts` and `get_deprecations` now check table existence via `getTableSchema()` instead of catching every `Throwable`. A missing table is reported as such; a genuine query failure surfaces via `SafeExecution` instead of being reported as "Table not found" / zero results.
- **`list_asset_folders` null dereference.** `getRootFolderByVolumeId()` can return null (volume with no indexed root folder); it was dereferenced unguarded. Now returns an empty list in that case.
- **`list_backups` / `create_backup` `TypeError`.** `filesize()`/`filemtime()` return `false` if a backup file is removed mid-listing (TOCTOU); under `strict_types` that `false` fed into `int` parameters throws. Now guarded (skip the vanished file / coerce to 0).
- **Undeclared PHP 8.4 dependency.** `array_any()` (PHP 8.4) is used at 4 sites while composer declares `php: ^8.3`; it only worked because `symfony/polyfill-php84` arrived transitively. Declared it explicitly (same undeclared-transitive-dependency class as the earlier psysh/finder fixes).
- Removed two dead null-coalesce/ternary branches PHPStan flags (`CraftTools` `schemaVersion`, `GraphqlTools` `getSchemaDef`).

## Test plan

- [x] 176 tests pass (13 new for `SqlReadGuard`, written test-first); PHPStan, Rector, Pint all clean
- [x] Live re-verification against a real Craft install: `run_query`/`explain_query` accept `dateCreated`/`dateUpdated` and still block writes and multi-statement DDL; `get_deprecations`, `get_table_counts`, `list_asset_folders`, `get_system_info` all green
