### PR TITLE
feat: field input shapes in describe_entry_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `elements` module: element-generic payload engine (natural keys for relations, draft-first writes, schema discovery), reusable outside the plugin (imports only craftcms/cms and psr/log, enforced by an architecture test)
 - `describe_entry_schema` tool: fields, kinds, required flags, matrix block types, native fields, writable meta attributes, optional golden-fixture `example`
+- `describe_entry_schema` now returns a per-field `input` shape describing the payload each field accepts: relations show their natural-key shape (e.g. `{section, slug}`), Matrix and Hyper-style fields recurse into their block/link types and sub-fields, core Link fields list their configured types and key shapes, option fields list allowed values, tables list their columns, scalars show their value type. Derived dynamically from field layouts and the module's own key contract, so it stays correct for any field including third-party ones.
 - `publish_entry`, `delete_entry`, `duplicate_entry`, `copy_entry_to_site` workflow tools
 - `entryWriteMode` setting (`'draft'` default, `'live'` restores immediate saves); per-call `mode` override
 - `site` parameter on all entry tools ([#9](https://github.com/stimmtdigital/craft-mcp/issues/9)); `search` on `list_entries`, `parent` on the entry write tools

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Requirements:
 ### Schema & Structure Tools
 | Name | Notes |
 |------|-------|
-| Describe Entry Schema | Everything needed to write a valid entry first try: fields, kinds, required flags, matrix block types (depth-expanded), native fields, writable meta attributes, and an optional real entry as a golden-fixture example |
+| Describe Entry Schema | Everything needed to write a valid entry first try: fields, kinds, required flags, matrix block types (depth-expanded), native fields, writable meta attributes, an optional real entry as a golden-fixture example, and per-field `input` shapes describing the payload each field accepts |
 | List Sections | Inspect all sections with their entry types; filter by handle/name search |
 | List Fields | Get all fields with types and settings; filter by search term or field type |
 | List Volumes | Inspect asset volume configurations and filesystem settings |
@@ -310,6 +310,7 @@ Entry reads and writes share one format, powered by an element-generic `elements
 - **Draft-first**: writes land as drafts with a `cpEditUrl` deep link for human review; `publish_entry` (or a reviewer in the control panel) makes them live. Set `entryWriteMode: 'live'` in `config/mcp.php` to restore immediate saves.
 - **Structured feedback**: validation failures return per-field errors; unresolvable natural keys become warnings on an otherwise successful save, never a guess or a silent drop.
 - **Third-party friendly**: any field type round-trips via Craft's own serialize contract; fields extending the core relation/Matrix types get natural keys automatically; `EVENT_REGISTER_FIELD_TRANSLATORS` covers fields that embed element ids in custom formats.
+- **Per-field input shapes**: read the `input` structure for each field from `describe_entry_schema` to understand the exact payload shape each field accepts (natural-key format for relations, block types for Matrix, allowed values for options, etc.).
 
 ## Extending
 

--- a/src/elements/refs/Keys.php
+++ b/src/elements/refs/Keys.php
@@ -72,6 +72,21 @@ final readonly class Keys {
         return $this->queryKey($elementType, $id, $site);
     }
 
+    /**
+     * The natural-key field list for a target element class, or null when the
+     * type has no natural key. Single source of truth shared with the schema
+     * describer so a documented shape never drifts from idFor()/keyFor().
+     *
+     * @return string[]|null
+     */
+    public function keyShape(string $elementType): ?array {
+        if ($elementType === Asset::class) {
+            return ['volume', 'path?', 'filename'];
+        }
+
+        return self::SHAPES[$elementType] ?? null;
+    }
+
     private function wellFormed(string $elementType, array $key): bool {
         $shape = self::SHAPES[$elementType] ?? null;
         if ($shape === null) {

--- a/src/elements/refs/Link.php
+++ b/src/elements/refs/Link.php
@@ -22,7 +22,7 @@ use stimmt\craft\Mcp\elements\Warning;
  * @author Max van Essen <support@stimmt.digital>
  */
 final readonly class Link implements FieldTranslator {
-    private const array TARGETS = [
+    public const array TARGETS = [
         'entry' => Entry::class,
         'asset' => Asset::class,
         'category' => Category::class,

--- a/src/elements/schema/Describer.php
+++ b/src/elements/schema/Describer.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace stimmt\craft\Mcp\elements\schema;
 
-use craft\base\FieldInterface;
 use craft\fieldlayoutelements\BaseNativeField;
 use craft\fieldlayoutelements\CustomField;
-use craft\fields\Addresses;
 use craft\fields\BaseRelationField;
-use craft\fields\ContentBlock;
-use craft\fields\Link;
 use craft\fields\Matrix;
 use craft\models\EntryType;
 use craft\models\FieldLayout;
@@ -24,6 +20,12 @@ use craft\models\FieldLayout;
  * @author Max van Essen <support@stimmt.digital>
  */
 final class Describer {
+    private readonly Shape $shape;
+
+    public function __construct(?Shape $shape = null) {
+        $this->shape = $shape ?? new Shape();
+    }
+
     public function describe(?FieldLayout $layout, int $depth = 1): array {
         return $this->fields($layout, $depth, top: true);
     }
@@ -60,14 +62,16 @@ final class Describer {
 
     private function field(CustomField $element, int $depth, bool $top): array {
         $field = $element->getField();
+        $input = $this->shape->of($field, $depth + 1);
 
         $described = [
             'handle' => (string) $field->handle,
             'name' => (string) $field->name,
             'type' => $field::class,
-            'kind' => $this->kind($field),
+            'kind' => $input['kind'],
             'instructions' => $field->instructions ?? '',
             'required' => $element->required,
+            'input' => $input,
         ];
 
         if ($field instanceof BaseRelationField) {
@@ -88,16 +92,6 @@ final class Describer {
         }
 
         return $described;
-    }
-
-    private function kind(FieldInterface $field): string {
-        return match (true) {
-            $field instanceof Matrix => 'matrix',
-            $field instanceof BaseRelationField => 'relation',
-            $field instanceof Link => 'link',
-            $field instanceof ContentBlock, $field instanceof Addresses => 'container',
-            default => 'plain',
-        };
     }
 
     private function expandedBlockTypes(Matrix $field, int $depth): array {

--- a/src/elements/schema/Describer.php
+++ b/src/elements/schema/Describer.php
@@ -19,8 +19,8 @@ use craft\models\FieldLayout;
  *
  * @author Max van Essen <support@stimmt.digital>
  */
-final class Describer {
-    private readonly Shape $shape;
+final readonly class Describer {
+    private Shape $shape;
 
     public function __construct(?Shape $shape = null) {
         $this->shape = $shape ?? new Shape();

--- a/src/elements/schema/Describer.php
+++ b/src/elements/schema/Describer.php
@@ -16,6 +16,8 @@ use craft\models\FieldLayout;
  * layout-level overrides, native layout fields, Matrix block types with
  * depth-limited expansion (depth > 0 expands sub-fields one level shallower
  * per recursion; a top-level matrix at depth 0 still names its block types).
+ * Every field also carries a machine-readable input shape from Shape, which
+ * is the single source of the field's kind.
  *
  * @author Max van Essen <support@stimmt.digital>
  */

--- a/src/elements/schema/Shape.php
+++ b/src/elements/schema/Shape.php
@@ -68,13 +68,13 @@ final readonly class Shape {
      */
     public function ofLayout(?FieldLayout $layout, int $depth = 2): array {
         if ($layout === null) {
-            return ['native' => [], 'fields' => []];
+            return ['natives' => [], 'fields' => []];
         }
 
-        $native = [];
+        $natives = [];
         foreach ($layout->getElementsByType(BaseNativeField::class) as $element) {
             /** @var BaseNativeField $element */
-            $native[] = ['attribute' => $element->attribute(), 'required' => (bool) $element->required];
+            $natives[] = ['attribute' => $element->attribute(), 'required' => (bool) $element->required];
         }
 
         $fields = [];
@@ -82,7 +82,7 @@ final readonly class Shape {
             $fields[$handle] = ['input' => $this->of($field, $depth)];
         }
 
-        return ['native' => $native, 'fields' => $fields];
+        return ['natives' => $natives, 'fields' => $fields];
     }
 
     /**

--- a/src/elements/schema/Shape.php
+++ b/src/elements/schema/Shape.php
@@ -19,6 +19,7 @@ use craft\models\FieldLayout;
 use stimmt\craft\Mcp\elements\LayoutFields;
 use stimmt\craft\Mcp\elements\refs\Keys;
 use stimmt\craft\Mcp\elements\refs\Link as LinkRef;
+use Stringable;
 use Throwable;
 
 /**
@@ -122,11 +123,20 @@ final readonly class Shape {
             return $this->links($field, $depth);
         }
 
-        if ($field instanceof ElementContainerFieldInterface) {
-            return $this->container($field, $depth);
-        }
+        return $this->maybeContainer($field, $depth) ?? $this->objectProbe($field, $depth);
+    }
 
-        return $this->objectProbe($field, $depth);
+    /**
+     * A fillable-container shape, or null when the field is not a container
+     * or has no nested layout to fill (so probed() falls through to object
+     * or scalar).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function maybeContainer(FieldInterface $field, int $depth): ?array {
+        return $field instanceof ElementContainerFieldInterface
+            ? $this->container($field, $depth)
+            : null;
     }
 
     /**
@@ -261,12 +271,22 @@ final readonly class Shape {
     }
 
     /**
-     * @return array<string, mixed>
+     * A container with no field-layout providers has no nested layout to
+     * fill, so it is not a fields-container in the write sense (a rich-text
+     * field that merely CAN embed entries lands here). Returning null lets
+     * probed() fall through to the scalar description of its stored value.
+     *
+     * @return array<string, mixed>|null
      */
-    private function container(ElementContainerFieldInterface $field, int $depth): array {
+    private function container(ElementContainerFieldInterface $field, int $depth): ?array {
+        $providers = array_values($field->getFieldLayoutProviders());
+        if ($providers === []) {
+            return null;
+        }
+
         $described = array_map(
             fn (object $provider): array => $this->ofLayout($provider->getFieldLayout(), $depth - 1),
-            array_values($field->getFieldLayoutProviders()),
+            $providers,
         );
 
         $shape = ['kind' => 'container', 'payload' => '{fields: {...}} or list of {fields: {...}}'];
@@ -289,8 +309,15 @@ final readonly class Shape {
     private function scalar(FieldInterface $field): array {
         $valueType = $field::phpType();
         $shape = ['kind' => 'scalar', 'valueType' => $valueType];
+
+        // A stringable value object (rich-text/HTML field data, colours, and
+        // the like) serialises from a plain string, so tell the agent to send
+        // one rather than leaving an opaque class name as the only signal.
+        $class = ltrim(explode('|', $valueType)[0], '\\');
         if (str_contains($valueType, 'DateTime')) {
             $shape['hint'] = 'ISO 8601 date-time string';
+        } elseif (str_contains($class, '\\') && is_a($class, Stringable::class, true)) {
+            $shape['hint'] = 'pass a string value (rich-text fields expect HTML markup)';
         }
 
         return $shape;

--- a/src/elements/schema/Shape.php
+++ b/src/elements/schema/Shape.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\elements\schema;
+
+use craft\base\ElementContainerFieldInterface;
+use craft\base\FieldInterface;
+use craft\fieldlayoutelements\BaseNativeField;
+use craft\fields\BaseOptionsField;
+use craft\fields\BaseRelationField;
+use craft\fields\data\MultiOptionsFieldData;
+use craft\fields\Link as LinkField;
+use craft\fields\Matrix;
+use craft\fields\Table;
+use craft\models\FieldLayout;
+use stimmt\craft\Mcp\elements\LayoutFields;
+use stimmt\craft\Mcp\elements\refs\Keys;
+use stimmt\craft\Mcp\elements\refs\Link as LinkRef;
+use Throwable;
+
+/**
+ * Resolves a machine-readable input descriptor for a field, mirroring the
+ * elements module's own payload contract (natural keys for relations, block
+ * handles for Matrix, ref-string links, etc.). Core structural bases are
+ * matched by instanceof BEFORE any duck-typed capability probe so a core
+ * class can never be swallowed by a probe; third-party nesting (Hyper link
+ * types, layout-backed fields) is reached generically through those probes,
+ * never by naming a plugin class. No GraphQL, no per-type mappers.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class Shape {
+    public function __construct(
+        private readonly Keys $keys = new Keys(),
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function of(FieldInterface $field, int $depth = 2): array {
+        try {
+            return $this->resolve($field, $depth);
+        } catch (Throwable $e) {
+            return $this->scalar($field) + [
+                'note' => 'structure introspection failed',
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function ofLayout(?FieldLayout $layout, int $depth = 2): array {
+        if ($layout === null) {
+            return ['native' => [], 'fields' => []];
+        }
+
+        $native = [];
+        foreach ($layout->getElementsByType(BaseNativeField::class) as $element) {
+            /** @var BaseNativeField $element */
+            $native[] = ['attribute' => $element->attribute(), 'required' => (bool) $element->required];
+        }
+
+        $fields = [];
+        foreach (LayoutFields::of($layout) as $handle => $field) {
+            $fields[$handle] = ['input' => $this->of($field, $depth)];
+        }
+
+        return ['native' => $native, 'fields' => $fields];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolve(FieldInterface $field, int $depth): array {
+        if ($depth <= 0) {
+            return ['kind' => 'nested', 'truncated' => true];
+        }
+
+        return $this->core($field, $depth) ?? $this->probed($field, $depth) ?? $this->scalar($field);
+    }
+
+    /**
+     * Core structural bases, matched by instanceof before any duck probe.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function core(FieldInterface $field, int $depth): ?array {
+        return match (true) {
+            $field instanceof BaseRelationField => $this->relation($field),
+            $field instanceof Matrix => $this->matrix($field, $depth),
+            $field instanceof LinkField => $this->link($field),
+            $field instanceof BaseOptionsField => $this->options($field),
+            $field instanceof Table => $this->table($field),
+            default => null,
+        };
+    }
+
+    /**
+     * Duck-typed capability probes for third-party fields; conventionally
+     * named accessors only, no plugin class is ever imported or named.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function probed(FieldInterface $field, int $depth): ?array {
+        if (method_exists($field, 'getLinkTypes')) {
+            return $this->links($field, $depth);
+        }
+
+        if ($field instanceof ElementContainerFieldInterface) {
+            return $this->container($field, $depth);
+        }
+
+        return $this->objectProbe($field, $depth);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function objectProbe(FieldInterface $field, int $depth): ?array {
+        if (!method_exists($field, 'getFieldLayout')) {
+            return null;
+        }
+
+        $layout = $field->getFieldLayout();
+
+        return $layout instanceof FieldLayout
+            ? ['kind' => 'object', 'fields' => $this->ofLayout($layout, $depth - 1)]
+            : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function relation(BaseRelationField $field): array {
+        return [
+            'kind' => 'relation',
+            'multiple' => true,
+            'elementType' => $field::elementType(),
+            'item' => $this->keys->keyShape($field::elementType()) ?? 'element id (no natural key for this type)',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function matrix(Matrix $field, int $depth): array {
+        $blockTypes = [];
+        foreach ($field->getEntryTypes() as $type) {
+            $blockTypes[(string) $type->handle] = [
+                'hasTitleField' => (bool) $type->hasTitleField,
+                'fields' => $this->ofLayout($type->getFieldLayout(), $depth - 1),
+            ];
+        }
+
+        return ['kind' => 'matrix', 'payload' => '{blockKey: {type, enabled, title?, fields}}', 'blockTypes' => $blockTypes];
+    }
+
+    /**
+     * Core Link fields: reads the configured $types setting, not
+     * getLinkTypes(), whose link-type objects carry no handle or layout and
+     * need Craft services to instantiate.
+     *
+     * @return array<string, mixed>
+     */
+    private function link(LinkField $field): array {
+        $types = [];
+        foreach ($field->types as $typeId) {
+            $target = LinkRef::TARGETS[$typeId] ?? null;
+            $types[(string) $typeId] = $target === null ? null : $this->keys->keyShape($target);
+        }
+
+        return [
+            'kind' => 'link',
+            'payload' => 'single link object: {type, value, key?}; value is a URL or existing ref string; for element types pass key instead',
+            'types' => $types,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function options(BaseOptionsField $field): array {
+        $values = [];
+        foreach ($field->options as $option) {
+            if (is_array($option) && isset($option['value'])) {
+                $values[] = (string) $option['value'];
+            }
+        }
+
+        return [
+            'kind' => 'options',
+            'multiple' => str_contains($field::phpType(), MultiOptionsFieldData::class),
+            'allowedValues' => $values,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function table(Table $field): array {
+        $columns = [];
+        foreach ($field->columns as $colId => $column) {
+            $columns[(string) $colId] = [
+                'handle' => $column['handle'] ?? null,
+                'heading' => $column['heading'] ?? null,
+                'type' => $column['type'] ?? null,
+            ];
+        }
+
+        return ['kind' => 'table', 'payload' => 'list of row objects keyed by column handle (or colN)', 'columns' => $columns];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function links(FieldInterface $field, int $depth): array {
+        $linkTypes = [];
+        foreach ($this->linkTypesOf($field) as $key => $linkType) {
+            if (($linkType->enabled ?? true) !== true) {
+                continue;
+            }
+
+            $handle = (string) ($linkType->handle ?? $key);
+            $layout = method_exists($linkType, 'getFieldLayout') ? $linkType->getFieldLayout() : null;
+            $linkTypes[$handle] = ['fields' => $this->ofLayout($layout, $depth - 1)];
+        }
+
+        return [
+            'kind' => 'links',
+            'payload' => 'list of link objects; identify each by handle or type; sub-fields per linkTypes',
+            'linkTypes' => $linkTypes,
+        ];
+    }
+
+    /**
+     * PHPStan boundary: getLinkTypes() is a duck-typed probe method, not
+     * declared on FieldInterface, so the call is routed through an
+     * object-typed parameter instead of widening FieldInterface itself.
+     *
+     * @return array<int|string, object>
+     */
+    private function linkTypesOf(object $field): array {
+        return $field->getLinkTypes();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function container(ElementContainerFieldInterface $field, int $depth): array {
+        $described = array_map(
+            fn (object $provider): array => $this->ofLayout($provider->getFieldLayout(), $depth - 1),
+            array_values($field->getFieldLayoutProviders()),
+        );
+
+        $shape = ['kind' => 'container', 'payload' => '{fields: {...}} or list of {fields: {...}}'];
+
+        return count($described) === 1
+            ? $shape + ['fields' => $described[0]]
+            : $shape + ['variants' => $described];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function scalar(FieldInterface $field): array {
+        $valueType = $field::phpType();
+        $shape = ['kind' => 'scalar', 'valueType' => $valueType];
+        if (str_contains($valueType, 'DateTime')) {
+            $shape['hint'] = 'ISO 8601 date-time string';
+        }
+
+        return $shape;
+    }
+}

--- a/src/elements/schema/Shape.php
+++ b/src/elements/schema/Shape.php
@@ -253,7 +253,7 @@ final readonly class Shape {
 
         return [
             'kind' => 'links',
-            'payload' => 'list of link objects; identify each by handle or type; sub-fields per linkTypes',
+            'payload' => 'list of link objects; identify each by handle (or type); put native attributes (linkValue, linkText, ...) at the top level and custom sub-fields under a nested "fields" object keyed by handle',
             'note' => self::UNTRANSLATED_NOTE,
             'linkTypes' => $linkTypes,
         ];

--- a/src/elements/schema/Shape.php
+++ b/src/elements/schema/Shape.php
@@ -30,9 +30,9 @@ use Throwable;
  *
  * @author Max van Essen <support@stimmt.digital>
  */
-final class Shape {
+final readonly class Shape {
     public function __construct(
-        private readonly Keys $keys = new Keys(),
+        private Keys $keys = new Keys(),
     ) {
     }
 

--- a/src/elements/schema/Shape.php
+++ b/src/elements/schema/Shape.php
@@ -7,8 +7,10 @@ namespace stimmt\craft\Mcp\elements\schema;
 use craft\base\ElementContainerFieldInterface;
 use craft\base\FieldInterface;
 use craft\fieldlayoutelements\BaseNativeField;
+use craft\fields\Addresses;
 use craft\fields\BaseOptionsField;
 use craft\fields\BaseRelationField;
+use craft\fields\ContentBlock;
 use craft\fields\data\MultiOptionsFieldData;
 use craft\fields\Link as LinkField;
 use craft\fields\Matrix;
@@ -31,6 +33,16 @@ use Throwable;
  * @author Max van Essen <support@stimmt.digital>
  */
 final readonly class Shape {
+    /**
+     * Attached to shapes whose parent field the module's Writer does not
+     * translate (Hyper-style link fields, generic layout-backed fields, and
+     * third-party containers). Their nested values reach Craft raw, so an
+     * agent must send stored IDs or ref strings there, not natural keys. The
+     * translated core containers (Matrix, ContentBlock, Addresses) do resolve
+     * natural keys and never carry this note.
+     */
+    private const string UNTRANSLATED_NOTE = 'nested values pass through unchanged: relation and link sub-fields here take stored IDs or ref strings, not natural keys';
+
     public function __construct(
         private Keys $keys = new Keys(),
     ) {
@@ -128,7 +140,7 @@ final readonly class Shape {
         $layout = $field->getFieldLayout();
 
         return $layout instanceof FieldLayout
-            ? ['kind' => 'object', 'fields' => $this->ofLayout($layout, $depth - 1)]
+            ? ['kind' => 'object', 'note' => self::UNTRANSLATED_NOTE, 'fields' => $this->ofLayout($layout, $depth - 1)]
             : null;
     }
 
@@ -232,6 +244,7 @@ final readonly class Shape {
         return [
             'kind' => 'links',
             'payload' => 'list of link objects; identify each by handle or type; sub-fields per linkTypes',
+            'note' => self::UNTRANSLATED_NOTE,
             'linkTypes' => $linkTypes,
         ];
     }
@@ -257,6 +270,13 @@ final readonly class Shape {
         );
 
         $shape = ['kind' => 'container', 'payload' => '{fields: {...}} or list of {fields: {...}}'];
+
+        // Matrix is handled in core(); the only core containers the Writer
+        // translates that reach here are ContentBlock and Addresses. Anything
+        // else is a third-party container whose nested values pass through raw.
+        if (!$field instanceof ContentBlock && !$field instanceof Addresses) {
+            $shape['note'] = self::UNTRANSLATED_NOTE;
+        }
 
         return count($described) === 1
             ? $shape + ['fields' => $described[0]]

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -179,7 +179,7 @@ class EntryTools {
 
     #[McpTool(
         name: 'describe_entry_schema',
-        description: 'Describe the fields a section/entry type accepts: handles, kinds, required flags, matrix block types (depth-expanded), native fields, writable meta attributes. Pass example (entry id or slug) to include a real entry payload as a golden fixture.',
+        description: 'Describe the fields a section/entry type accepts: handles, kinds, required flags, a per-field input shape (the exact payload each field takes: natural keys for relations, block types for matrix, link/option/table/container shapes for structured and third-party fields), native fields, writable meta attributes. Pass example (entry id or slug) to include a real entry payload as a golden fixture.',
     )]
     #[McpToolMeta(category: ToolCategory::SCHEMA)]
     public function describeEntrySchema(

--- a/tests/Unit/Elements/Refs/KeysTest.php
+++ b/tests/Unit/Elements/Refs/KeysTest.php
@@ -57,4 +57,14 @@ describe('Keys', function () {
         expect($keys->idFor(Entry::class, ['slug' => 'about'], null))->toBeNull()
             ->and($keys->idFor(User::class, [], null))->toBeNull();
     });
+
+    it('exposes the natural-key shape per target type', function () {
+        $keys = new Keys();
+
+        expect($keys->keyShape(Entry::class))->toBe(['section', 'slug'])
+            ->and($keys->keyShape(Category::class))->toBe(['group', 'slug'])
+            ->and($keys->keyShape(User::class))->toBe(['username'])
+            ->and($keys->keyShape(Asset::class))->toBe(['volume', 'path?', 'filename'])
+            ->and($keys->keyShape('some\\plugin\\Product'))->toBeNull();
+    });
 });

--- a/tests/Unit/Elements/Refs/KeysTest.php
+++ b/tests/Unit/Elements/Refs/KeysTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use craft\elements\Asset;
 use craft\elements\Category;
 use craft\elements\Entry;
+use craft\elements\GlobalSet;
 use craft\elements\Tag;
 use craft\elements\User;
 use stimmt\craft\Mcp\elements\refs\AssetKey;
@@ -63,7 +64,9 @@ describe('Keys', function () {
 
         expect($keys->keyShape(Entry::class))->toBe(['section', 'slug'])
             ->and($keys->keyShape(Category::class))->toBe(['group', 'slug'])
+            ->and($keys->keyShape(Tag::class))->toBe(['group', 'slug'])
             ->and($keys->keyShape(User::class))->toBe(['username'])
+            ->and($keys->keyShape(GlobalSet::class))->toBe(['handle'])
             ->and($keys->keyShape(Asset::class))->toBe(['volume', 'path?', 'filename'])
             ->and($keys->keyShape('some\\plugin\\Product'))->toBeNull();
     });

--- a/tests/Unit/Elements/Schema/DescriberTest.php
+++ b/tests/Unit/Elements/Schema/DescriberTest.php
@@ -28,10 +28,22 @@ describe('Describer', function () {
         expect($byHandle)->toHaveKeys(['body', 'related'])
             ->and($byHandle['body']['required'])->toBeTrue()
             ->and($byHandle['body']['instructions'])->toBe('Write here')
-            ->and($byHandle['body']['kind'])->toBe('plain')
+            ->and($byHandle['body']['kind'])->toBe('scalar')
             ->and($byHandle['related']['kind'])->toBe('relation')
             ->and($byHandle['related']['target']['elementType'])->toBe(craft\elements\Entry::class)
             ->and($byHandle['related']['target']['sources'])->toBe('*');
+    });
+
+    it('includes an input shape and derives kind from it', function () {
+        $body = new CustomField(new PlainText(['handle' => 'body']));
+        $related = new CustomField(new Entries(['handle' => 'related', 'showUnpermittedSections' => true]));
+
+        $byHandle = array_column((new Describer())->describe(Layouts::with([$body, $related])), null, 'handle');
+
+        expect($byHandle['body']['input']['kind'])->toBe('scalar')
+            ->and($byHandle['body']['kind'])->toBe('scalar')
+            ->and($byHandle['related']['kind'])->toBe('relation')
+            ->and($byHandle['related']['input']['item'])->toBe(['section', 'slug']);
     });
 
     it('lists native layout fields', function () {

--- a/tests/Unit/Elements/Schema/ShapeTest.php
+++ b/tests/Unit/Elements/Schema/ShapeTest.php
@@ -170,7 +170,8 @@ describe('Shape::of', function () {
 
         expect($out['kind'])->toBe('links')
             ->and($out['linkTypes'])->toHaveKey('url')
-            ->and($out['linkTypes']['url']['fields']['fields'])->toHaveKey('linkText');
+            ->and($out['linkTypes']['url']['fields']['fields'])->toHaveKey('linkText')
+            ->and($out['note'])->toContain('not natural keys');
     });
 
     it('describes a duck-typed layout-backed field as an object', function () {
@@ -184,7 +185,8 @@ describe('Shape::of', function () {
         $out = (new Shape())->of($field);
 
         expect($out['kind'])->toBe('object')
-            ->and($out['fields']['fields'])->toHaveKey('inner');
+            ->and($out['fields']['fields'])->toHaveKey('inner')
+            ->and($out['note'])->toContain('not natural keys');
     });
 
     it('truncates at depth zero', function () {

--- a/tests/Unit/Elements/Schema/ShapeTest.php
+++ b/tests/Unit/Elements/Schema/ShapeTest.php
@@ -227,7 +227,8 @@ describe('Shape::of', function () {
         expect($out['kind'])->toBe('links')
             ->and($out['linkTypes'])->toHaveKey('url')
             ->and($out['linkTypes']['url']['fields']['fields'])->toHaveKey('linkText')
-            ->and($out['note'])->toContain('not natural keys');
+            ->and($out['note'])->toContain('not natural keys')
+            ->and($out['payload'])->toContain('custom sub-fields under a nested "fields" object');
     });
 
     it('describes a duck-typed layout-backed field as an object', function () {

--- a/tests/Unit/Elements/Schema/ShapeTest.php
+++ b/tests/Unit/Elements/Schema/ShapeTest.php
@@ -195,7 +195,8 @@ describe('Shape::of', function () {
         $out = (new Shape())->ofLayout(Layouts::with([$dropdown]));
 
         expect($out['fields'])->toHaveKey('style')
-            ->and($out['fields']['style']['input']['allowedValues'])->toBe(['a']);
+            ->and($out['fields']['style']['input']['allowedValues'])->toBe(['a'])
+            ->and($out['natives'])->toBe([]);
     });
 
     it('describes a duck-typed link field generically without naming its class', function () {

--- a/tests/Unit/Elements/Schema/ShapeTest.php
+++ b/tests/Unit/Elements/Schema/ShapeTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 require_once dirname(__DIR__, 3) . '/Fixtures/CraftStub.php';
 require_once dirname(__DIR__, 4) . '/vendor/yiisoft/yii2/Yii.php';
 
+use craft\base\ElementContainerFieldInterface;
+use craft\base\NestedElementInterface;
 use craft\elements\Entry;
+use craft\elements\User;
 use craft\fieldlayoutelements\CustomField;
 use craft\fields\Checkboxes;
+use craft\fields\Color;
 use craft\fields\Date;
 use craft\fields\Dropdown;
 use craft\fields\Entries;
@@ -21,6 +25,58 @@ use craft\models\EntryType;
 use craft\models\FieldLayout;
 use stimmt\craft\Mcp\elements\schema\Shape;
 use stimmt\craft\Mcp\Tests\Fixtures\Layouts;
+
+/**
+ * A field implementing Craft's container interface with a configurable
+ * provider list, so both the fillable-container path and the empty
+ * (rich-text-style) fallthrough can be exercised without a plugin dependency.
+ *
+ * @param array<int, object> $providers
+ */
+function shapeContainerField(array $providers): ElementContainerFieldInterface {
+    return new class ($providers) extends PlainText implements ElementContainerFieldInterface {
+        /** @param array<int, object> $providers */
+        public function __construct(private array $providers) {
+            parent::__construct(['handle' => 'nested']);
+        }
+
+        public function getFieldLayoutProviders(): array {
+            return $this->providers;
+        }
+
+        public function getUriFormatForElement(NestedElementInterface $element): ?string {
+            return null;
+        }
+
+        public function getRouteForElement(NestedElementInterface $element): mixed {
+            return null;
+        }
+
+        public function getSupportedSitesForElement(NestedElementInterface $element): array {
+            return [];
+        }
+
+        public function canViewElement(NestedElementInterface $element, User $user): ?bool {
+            return null;
+        }
+
+        public function canSaveElement(NestedElementInterface $element, User $user): ?bool {
+            return null;
+        }
+
+        public function canDuplicateElement(NestedElementInterface $element, User $user): ?bool {
+            return null;
+        }
+
+        public function canDeleteElement(NestedElementInterface $element, User $user): ?bool {
+            return null;
+        }
+
+        public function canDeleteElementForSite(NestedElementInterface $element, User $user): ?bool {
+            return null;
+        }
+    };
+}
 
 describe('Shape::of', function () {
     // Number::dbType() reads Craft::$app->getDb() during Field::init(), even
@@ -187,6 +243,34 @@ describe('Shape::of', function () {
         expect($out['kind'])->toBe('object')
             ->and($out['fields']['fields'])->toHaveKey('inner')
             ->and($out['note'])->toContain('not natural keys');
+    });
+
+    it('hints a plain string for stringable field-data value types', function () {
+        $out = (new Shape())->of(new Color(['handle' => 'accent']));
+
+        expect($out['kind'])->toBe('scalar')
+            ->and($out['valueType'])->toContain('ColorData')
+            ->and($out['hint'])->toContain('string');
+    });
+
+    it('describes a container with providers as a fillable fields shape', function () {
+        $provider = new class () {
+            public function getFieldLayout(): FieldLayout {
+                return Layouts::with([new CustomField(new PlainText(['handle' => 'inner']))]);
+            }
+        };
+
+        $out = (new Shape())->of(shapeContainerField([$provider]));
+
+        expect($out['kind'])->toBe('container')
+            ->and($out['note'])->toContain('not natural keys')
+            ->and($out['fields']['fields'])->toHaveKey('inner');
+    });
+
+    it('falls through to scalar when a container has no providers (rich-text style)', function () {
+        $out = (new Shape())->of(shapeContainerField([]));
+
+        expect($out['kind'])->toBe('scalar');
     });
 
     it('truncates at depth zero', function () {

--- a/tests/Unit/Elements/Schema/ShapeTest.php
+++ b/tests/Unit/Elements/Schema/ShapeTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 3) . '/Fixtures/CraftStub.php';
+require_once dirname(__DIR__, 4) . '/vendor/yiisoft/yii2/Yii.php';
+
+use craft\elements\Entry;
+use craft\fieldlayoutelements\CustomField;
+use craft\fields\Checkboxes;
+use craft\fields\Date;
+use craft\fields\Dropdown;
+use craft\fields\Entries;
+use craft\fields\Lightswitch;
+use craft\fields\Link as LinkField;
+use craft\fields\Matrix;
+use craft\fields\Number;
+use craft\fields\PlainText;
+use craft\fields\Table;
+use craft\models\EntryType;
+use craft\models\FieldLayout;
+use stimmt\craft\Mcp\elements\schema\Shape;
+use stimmt\craft\Mcp\Tests\Fixtures\Layouts;
+
+describe('Shape::of', function () {
+    // Number::dbType() reads Craft::$app->getDb() during Field::init(), even
+    // when the config carries no db-related setting; stub it the same way
+    // RegistryTest does, and restore it so no other test file inherits it.
+    beforeEach(function () {
+        $this->originalApp = Craft::$app;
+        $db = new class () {
+            public function getIsMysql(): bool {
+                return false;
+            }
+        };
+
+        Craft::$app = new class ($db) {
+            public function __construct(private readonly object $db) {
+            }
+
+            public function getDb(): object {
+                return $this->db;
+            }
+        };
+    });
+
+    afterEach(function () {
+        Craft::$app = $this->originalApp;
+    });
+
+    it('describes scalar fields by their php value type', function () {
+        expect((new Shape())->of(new PlainText(['handle' => 'body']))['kind'])->toBe('scalar')
+            ->and((new Shape())->of(new Number(['handle' => 'n']))['valueType'])->toContain('int')
+            ->and((new Shape())->of(new Lightswitch(['handle' => 'flag']))['valueType'])->toContain('bool');
+    });
+
+    it('hints the json format for date fields', function () {
+        $out = (new Shape())->of(new Date(['handle' => 'when']));
+
+        expect($out['kind'])->toBe('scalar')->and($out['hint'])->toContain('ISO 8601');
+    });
+
+    it('describes a relation field with its natural-key shape, not an id', function () {
+        $out = (new Shape())->of(new Entries(['handle' => 'related']));
+
+        expect($out['kind'])->toBe('relation')
+            ->and($out['item'])->toBe(['section', 'slug'])
+            ->and($out['elementType'])->toBe(Entry::class);
+    });
+
+    it('describes single and multi option fields with their allowed values', function () {
+        $options = [
+            ['label' => 'Small', 'value' => 'sm', 'default' => ''],
+            ['label' => 'Large', 'value' => 'lg', 'default' => ''],
+        ];
+        $single = (new Shape())->of(new Dropdown(['handle' => 'size', 'options' => $options]));
+        $multi = (new Shape())->of(new Checkboxes(['handle' => 'sizes', 'options' => $options]));
+
+        expect($single['kind'])->toBe('options')
+            ->and($single['multiple'])->toBeFalse()
+            ->and($single['allowedValues'])->toBe(['sm', 'lg'])
+            ->and($multi['multiple'])->toBeTrue();
+    });
+
+    it('describes the core link field by its configured types and key shapes', function () {
+        $out = (new Shape())->of(new LinkField(['handle' => 'cta', 'types' => ['url', 'entry']]));
+
+        expect($out['kind'])->toBe('link')
+            ->and($out['types'])->toBe(['url' => null, 'entry' => ['section', 'slug']]);
+    });
+
+    it('describes a table field by its columns', function () {
+        // addRowLabel is supplied so Table::init() skips its Craft::t() call,
+        // which the stub above (Craft::$app only) does not cover.
+        $table = new Table(['handle' => 'specs', 'addRowLabel' => 'Add a row', 'columns' => [
+            'col1' => ['handle' => 'label', 'heading' => 'Label', 'type' => 'singleline'],
+        ]]);
+
+        $out = (new Shape())->of($table);
+
+        expect($out['kind'])->toBe('table')
+            ->and($out['columns']['col1']['handle'])->toBe('label');
+    });
+
+    it('expands matrix block types into per-type field shapes', function () {
+        $layout = Layouts::with([new CustomField(new PlainText(['handle' => 'text']))]);
+        $type = new class ($layout) extends EntryType {
+            public function __construct(private readonly FieldLayout $blockLayout) {
+                parent::__construct(['handle' => 'contentBlock', 'hasTitleField' => true]);
+            }
+
+            public function getFieldLayout(): FieldLayout {
+                return $this->blockLayout;
+            }
+        };
+        $matrix = new class ($type) extends Matrix {
+            public function __construct(private readonly EntryType $only) {
+                parent::__construct(['handle' => 'builder']);
+            }
+
+            public function getEntryTypes(): array {
+                return [$this->only];
+            }
+        };
+
+        $out = (new Shape())->of($matrix);
+
+        expect($out['kind'])->toBe('matrix')
+            ->and($out['blockTypes']['contentBlock']['hasTitleField'])->toBeTrue()
+            ->and($out['blockTypes']['contentBlock']['fields']['fields'])->toHaveKey('text');
+    });
+
+    it('walks a layout into native attributes and recursed custom fields', function () {
+        $dropdown = new CustomField(new Dropdown([
+            'handle' => 'style',
+            'options' => [['label' => 'A', 'value' => 'a', 'default' => '']],
+        ]));
+
+        $out = (new Shape())->ofLayout(Layouts::with([$dropdown]));
+
+        expect($out['fields'])->toHaveKey('style')
+            ->and($out['fields']['style']['input']['allowedValues'])->toBe(['a']);
+    });
+
+    it('describes a duck-typed link field generically without naming its class', function () {
+        // A stand-in exposing getLinkTypes() the way Hyper does; proves the
+        // probe recurses link-type layouts with no plugin dependency and that
+        // a handle-less type falls back to its iteration key.
+        $field = new class () extends PlainText {
+            public function getLinkTypes(): array {
+                $layout = Layouts::with([
+                    new CustomField(new PlainText(['handle' => 'linkText'])),
+                ]);
+
+                return ['url' => new class ($layout) {
+                    public bool $enabled = true;
+
+                    public function __construct(private readonly FieldLayout $layout) {
+                    }
+
+                    public function getFieldLayout(): FieldLayout {
+                        return $this->layout;
+                    }
+                }];
+            }
+        };
+        $field->handle = 'buttons';
+
+        $out = (new Shape())->of($field);
+
+        expect($out['kind'])->toBe('links')
+            ->and($out['linkTypes'])->toHaveKey('url')
+            ->and($out['linkTypes']['url']['fields']['fields'])->toHaveKey('linkText');
+    });
+
+    it('describes a duck-typed layout-backed field as an object', function () {
+        $field = new class () extends PlainText {
+            public function getFieldLayout(): FieldLayout {
+                return Layouts::with([new CustomField(new PlainText(['handle' => 'inner']))]);
+            }
+        };
+        $field->handle = 'widget';
+
+        $out = (new Shape())->of($field);
+
+        expect($out['kind'])->toBe('object')
+            ->and($out['fields']['fields'])->toHaveKey('inner');
+    });
+
+    it('truncates at depth zero', function () {
+        expect((new Shape())->of(new PlainText(['handle' => 'body']), 0))
+            ->toBe(['kind' => 'nested', 'truncated' => true]);
+    });
+
+    it('degrades to an annotated scalar when introspection throws', function () {
+        $field = new class () extends PlainText {
+            public function getLinkTypes(): array {
+                throw new RuntimeException('plugin broke');
+            }
+        };
+        $field->handle = 'broken';
+
+        $out = (new Shape())->of($field);
+
+        expect($out['kind'])->toBe('scalar')
+            ->and($out['note'])->toBe('structure introspection failed')
+            ->and($out['error'])->toBe('plugin broke');
+    });
+});


### PR DESCRIPTION
## What

`describe_entry_schema` now returns a machine-readable `input` shape on every field, describing the exact payload that `create_entry` / `update_entry` accept for it. This closes the old `kind: plain` blind spot where an agent had to reverse-engineer how to fill a structured or third-party field.

Stacked on `feat/elements-module` (PR #25); merge that first.

## Shapes per field kind

- `relation`: the target's natural-key shape, e.g. `{ item: ["section", "slug"] }`, not a numeric id.
- `matrix`: each block type by handle, with its sub-fields expanded one level.
- `link` (core Link field): the configured link types mapped to their key shapes.
- `links` (Hyper-style fields): each enabled link type with its recursed sub-field layout (native `linkValue` and any custom sub-fields).
- `options`: allowed values, with `multiple` for multi-select.
- `table`: the configured columns.
- `container` (ContentBlock, Addresses, or any third-party container): the nested layout.
- `object`: generic layout-backed fields.
- `scalar`: the PHP value type, with an ISO 8601 hint for dates.

## How it is derived

Dynamically, from the same contracts the module already reads and writes through: core structural bases are matched by `instanceof` first, then third-party fields are reached by duck-typed capability probes (`getLinkTypes`, `getFieldLayout`) so no plugin class is ever imported or named. Relation and link shapes reuse the module's own natural-key source, so a documented shape cannot drift from what the writer accepts. No per-field-type mapping files, and no GraphQL.

Shapes whose parent field the writer does not translate (Hyper-style links, generic layout-backed fields, third-party containers) carry a `note` telling the agent that nested relation and link values there take stored ids or refs, not natural keys, since the writer passes those parents through unchanged.

`kind` is now sourced from the input shape itself, so kind and input can never disagree.

## Verify

- `describe_entry_schema` for a section whose type has a relation, a Matrix, and a Hyper field: the relation shows `input.item = ["section", "slug"]`, the Matrix shows its block types with sub-fields, and the Hyper field shows `kind: links` with each link type's native `linkValue` plus its recursed option sub-fields.
- `./vendor/bin/pest` (261 passing), plus PHPStan, Rector, and Pint all green.
