### PR TITLE
ci: beta release channel with drafted stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,17 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      # To cut a pre-release: git tag v1.4.0-beta.1 && git push origin v1.4.0-beta.1
+      # Pre-release tags publish immediately for testers; stable tags create a
+      # draft so the title and notes get a human pass before publishing.
+      - name: Determine release channel
+        id: channel
+        run: |
+          case "$GITHUB_REF_NAME" in
+            *-alpha*|*-beta*|*-rc*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Generate changelog
         id: changelog
         uses: orhun/git-cliff-action@v4
@@ -55,7 +66,7 @@ jobs:
             ```bash
             composer require stimmt/craft-mcp:^${{ steps.version.outputs.version }}
             ```
-          draft: false
-          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+          draft: ${{ steps.channel.outputs.prerelease == 'false' }}
+          prerelease: ${{ steps.channel.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,16 @@ After Composer finishes downloading the package, install the plugin through Craf
 php craft plugin/install mcp
 ```
 
+### Beta Releases
+
+Pre-releases are tagged like `v1.4.0-beta.1` and marked as pre-release on GitHub. Composer never installs them by accident: its default stability is `stable`, so regular installs keep resolving to the latest stable version. To test a beta, opt in explicitly:
+
+```bash
+composer require stimmt/craft-mcp:^1.4.0@beta
+```
+
+Most Craft projects ship with `minimum-stability: dev` and `prefer-stable: true` in their root `composer.json`, so an exact constraint like `^1.4.0-beta.1` also resolves without extra flags. When the stable version is released, the same constraint upgrades to it with a normal `composer update`.
+
 ### Local Development
 
 If you're contributing to Craft MCP or developing it locally, you can install from a local path:


### PR DESCRIPTION
## What

Formalizes the pre-release flow the release workflow already half-supported:

- Pre-release tags (`v*-alpha*`, `v*-beta*`, `v*-rc*`) publish their GitHub release immediately, marked as pre-release, so testers can install the moment the tag lands.
- Stable tags now create a **draft** release instead of publishing directly, so the title and notes get a human pass first (matching how past releases got their titles).
- `docs/installation.md` gains a Beta Releases section telling testers how to opt in (`composer require stimmt/craft-mcp:^X.Y.Z@beta`) and why betas can never install by accident.

## Cutting a beta

```
git tag v1.4.0-beta.1
git push origin v1.4.0-beta.1
```

Nothing else; the workflow does the rest.

## Verify

- Workflow logic: the `channel` step maps tag suffixes to `prerelease`; `draft`/`prerelease` flags are mutually exclusive by construction.
- Docs render: the new section sits under Install via Composer.