### PR TITLE
chore: one-command release cutting

### DIFF
--- a/.github/scripts/cut.php
+++ b/.github/scripts/cut.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Cut a release: turn the CHANGELOG's Unreleased section into a versioned
+ * section, commit, tag, and push in one go.
+ *
+ * Usage (from the repo root):
+ *   composer cut -- v1.4.0-beta.2            # pre-release
+ *   composer cut -- v1.4.0                   # stable
+ *   composer cut -- v1.4.0-beta.2 --dry-run  # show what would happen
+ *
+ * What it does:
+ *   1. Guards: valid tag, clean tree, on master, tag not taken, Unreleased
+ *      section not empty.
+ *   2. Retitles `## [Unreleased]` to `## [<version>] - <today>` and opens a
+ *      fresh empty `## [Unreleased]` above it.
+ *   3. Commits (`docs: changelog for <tag>`), tags, pushes commit and tag.
+ *      The Release workflow does the rest (pre-release tags publish
+ *      immediately; stable tags create a draft for a title pass).
+ *
+ * Stable releases after a beta run: the beta sections stay in the file as
+ * history; consolidating them under the stable heading is an editorial call,
+ * not this script's.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+
+$args = array_slice($argv, 1);
+$dryRun = in_array('--dry-run', $args, true);
+$tag = array_values(array_filter($args, static fn (string $a): bool => !str_starts_with($a, '--')))[0] ?? null;
+
+function fail(string $message): never {
+    fwrite(STDERR, "error: {$message}\n");
+    exit(1);
+}
+
+function run(string $command): string {
+    exec($command . ' 2>&1', $output, $code);
+    $text = implode("\n", $output);
+    if ($code !== 0) {
+        fail("`{$command}` failed:\n{$text}");
+    }
+
+    return $text;
+}
+
+if ($tag === null || !preg_match('/^v\d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?$/', $tag)) {
+    fail('pass a tag like v1.4.0 or v1.4.0-beta.2 (usage: composer cut -- <tag> [--dry-run])');
+}
+
+$changelogPath = dirname(__DIR__, 2) . '/CHANGELOG.md';
+$changelog = file_get_contents($changelogPath);
+if ($changelog === false) {
+    fail('CHANGELOG.md not found');
+}
+
+$version = substr($tag, 1);
+if (str_contains($changelog, "## [{$version}]")) {
+    fail("CHANGELOG.md already has a section for {$version}");
+}
+
+if (!preg_match('/## \[Unreleased\]\n(.*?)(?=\n## \[|\z)/s', $changelog, $match)) {
+    fail('no ## [Unreleased] section found');
+}
+
+if (trim($match[1]) === '') {
+    fail('the Unreleased section is empty; nothing to release');
+}
+
+if (run('git rev-parse --abbrev-ref HEAD') !== 'master') {
+    fail('cut releases from master');
+}
+
+if (run('git status --porcelain') !== '') {
+    fail('working tree is not clean');
+}
+
+if (run("git tag --list {$tag}") !== '') {
+    fail("tag {$tag} already exists");
+}
+
+$today = date('Y-m-d');
+$updated = str_replace(
+    "## [Unreleased]\n",
+    "## [Unreleased]\n\n## [{$version}] - {$today}\n",
+    $changelog,
+);
+
+if ($dryRun) {
+    echo "dry run: would retitle Unreleased to [{$version}] - {$today}, then:\n";
+    echo "  git commit -m \"docs: changelog for {$tag}\" CHANGELOG.md\n";
+    echo "  git tag {$tag} && git push origin master {$tag}\n\n";
+    echo "CHANGELOG head after the edit:\n";
+    echo implode("\n", array_slice(explode("\n", $updated), 0, 16)) . "\n";
+    exit(0);
+}
+
+file_put_contents($changelogPath, $updated);
+run('git add CHANGELOG.md');
+run("git commit -m \"docs: changelog for {$tag}\"");
+run("git tag {$tag}");
+run("git push origin master {$tag}");
+
+echo "{$tag} cut: changelog committed, tag pushed, the Release workflow takes it from here.\n";
+echo str_contains($tag, '-')
+    ? "Pre-release: it will publish itself; give it a title with `gh release edit {$tag} --title \"...\"`.\n"
+    : "Stable: a DRAFT release will appear; polish the title, then publish.\n";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0-beta.1] - 2026-07-09
+
 ### Added
 - `elements` module: element-generic payload engine (natural keys for relations, draft-first writes, schema discovery), reusable outside the plugin (imports only craftcms/cms and psr/log, enforced by an architecture test)
 - `describe_entry_schema` tool: fields, kinds, required flags, matrix block types, native fields, writable meta attributes, optional golden-fixture `example`

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
         }
     },
     "scripts": {
+        "cut": "php .github/scripts/cut.php",
         "lint": "pint",
         "lint:test": "pint --test",
         "refactor": "rector process",


### PR DESCRIPTION
## What

- `composer cut -- v1.4.0-beta.2` (or a stable `v1.4.0`): retitles the CHANGELOG's Unreleased section to the version with today's date, opens a fresh Unreleased, commits, tags, and pushes in one go. The Release workflow then publishes pre-releases immediately and drafts stables for a title pass.
- Guards: tag format, master-only, clean tree, tag not taken, no duplicate section, refuses an empty Unreleased.
- `--dry-run` previews the edit and the git commands without touching anything.
- Records the already-shipped 1.4.0-beta.1 section in the CHANGELOG retroactively (its content was under Unreleased when the tag was cut).

Beta sections stay in the file as history; folding them into the stable section at release time remains an editorial call.

## Verify

- Sandbox run: happy-path dry run produces the expected retitle; bad-tag, existing-section, wrong-branch, and empty-section guards all abort with exit 1.
- `composer validate --strict` unaffected; test suite untouched and green.