### PR TITLE
ci: fix rector drift and pin its version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18",
-        "rector/rector": "^2.0",
+        "rector/rector": "2.5.5",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "phpstan/phpstan": "^2.0",

--- a/src/tools/AssetTools.php
+++ b/src/tools/AssetTools.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\tools;
 
 use Craft;
 use craft\elements\Asset;
+use craft\models\FieldLayout;
 use craft\models\VolumeFolder;
 use craft\services\Assets;
 use Mcp\Capability\Attribute\McpTool;
@@ -240,7 +241,7 @@ class AssetTools {
 
             // Custom fields
             $fieldValues = [];
-            if ($asset->getFieldLayout()) {
+            if ($asset->getFieldLayout() instanceof FieldLayout) {
                 foreach ($asset->getFieldLayout()->getCustomFields() as $field) {
                     $value = $asset->getFieldValue($field->handle);
                     $fieldValues[$field->handle] = Serializer::serialize($value);


### PR DESCRIPTION
## What

Both post-merge master CI runs went red on the Rector step, not on the bumped actions: CI installs dependencies fresh, and rector 2.5.5 (released between the Dependabot PRs' pre-merge runs and their merges) added a rule flagging a truthy field-layout check in AssetTools.

- Applies the finding (instanceof FieldLayout check).
- Pins rector/rector to 2.5.5 exactly: fresh CI installs stop drifting on their own, and Dependabot proposes future bumps deliberately (this is the third drift incident of this kind).

## Verify

Full local gate green on rector 2.5.5: pest 279, phpstan, rector dry-run, pint.