### PR TITLE
fix: self-refresh on external project config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The long-lived stdio server now detects external project config changes (migrations, `project-config/apply`, control panel edits) before each tool call and refreshes itself, ending `StaleResourceException` on writes and silently stale schema reads. No more manual `reload_mcp` after running migrations. Thanks @dgaidula for the report and groundwork in #18.
+
 ## [1.4.0-beta.1] - 2026-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- The long-lived stdio server now detects external project config changes (migrations, `project-config/apply`, control panel edits) before each tool call and refreshes itself, ending `StaleResourceException` on writes and silently stale schema reads. No more manual `reload_mcp` after running migrations. Thanks @dgaidula for the report and groundwork in #18.
+- The long-lived stdio server now detects external project config changes (migrations, `project-config/apply`, control panel edits) before each tool call and refreshes itself, ending `StaleResourceException` on writes and silently stale schema reads across the whole read surface (fields and layouts, sections and entry types, sites, volumes, category groups, global sets). No more manual `reload_mcp` after running migrations. Thanks @dgaidula for the report and groundwork in #18.
 
 ## [1.4.0-beta.1] - 2026-07-09
 

--- a/src/support/ConfigFreshness.php
+++ b/src/support/ConfigFreshness.php
@@ -12,7 +12,8 @@ use Throwable;
 /**
  * Detects external project config changes before a tool runs and refreshes
  * the long-lived server's in-process state (cached Info, ProjectConfig,
- * field and section memos). Proactive counterpart to Craft's stale check:
+ * field, field-layout, and section memos). Proactive counterpart to Craft's
+ * stale check:
  * the same configVersion comparison _acquireLock() uses to throw
  * StaleResourceException, done first so writes succeed and reads are fresh.
  * Fail-open by design: a failing probe must never block a tool call.
@@ -57,6 +58,7 @@ final class ConfigFreshness {
         Craft::$app->getIsInstalled(true);
         PluginReloader::resetProjectConfig();
         Craft::$app->getFields()->refreshFields();
+        PluginReloader::resetFieldLayoutsMemo();
         PluginReloader::resetEntriesMemos();
         Craft::info('Project config changed externally; refreshed in-process state', __METHOD__);
     }

--- a/src/support/ConfigFreshness.php
+++ b/src/support/ConfigFreshness.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Craft;
+use craft\db\Query;
+use craft\db\Table;
+use Throwable;
+
+/**
+ * Detects external project config changes before a tool runs and refreshes
+ * the long-lived server's in-process state (cached Info, ProjectConfig,
+ * field and section memos). Proactive counterpart to Craft's stale check:
+ * the same configVersion comparison _acquireLock() uses to throw
+ * StaleResourceException, done first so writes succeed and reads are fresh.
+ * Fail-open by design: a failing probe must never block a tool call.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class ConfigFreshness {
+    public static function ensure(): void {
+        try {
+            if (!self::applicable()) {
+                return;
+            }
+
+            $loaded = Craft::$app->getInfo()->configVersion;
+            if (self::isStale(self::storedVersion(), $loaded)) {
+                self::refresh();
+            }
+        } catch (Throwable $e) {
+            Craft::warning('Config freshness probe failed: ' . $e->getMessage(), __METHOD__);
+        }
+    }
+
+    public static function isStale(?string $stored, ?string $loaded): bool {
+        return $stored !== null && $loaded !== null && $stored !== $loaded;
+    }
+
+    private static function applicable(): bool {
+        return Craft::$app !== null
+            && method_exists(Craft::$app, 'getInfo')
+            && Craft::$app->getIsInstalled();
+    }
+
+    private static function storedVersion(): ?string {
+        $version = (new Query())->select(['configVersion'])->from([Table::INFO])->scalar();
+
+        return is_string($version) && $version !== '' ? $version : null;
+    }
+
+    private static function refresh(): void {
+        // Public API that nulls the cached Info model, so the next stale
+        // check compares against a fresh configVersion.
+        Craft::$app->getIsInstalled(true);
+        PluginReloader::resetProjectConfig();
+        Craft::$app->getFields()->refreshFields();
+        PluginReloader::resetEntriesMemos();
+        Craft::info('Project config changed externally; refreshed in-process state', __METHOD__);
+    }
+}

--- a/src/support/ConfigFreshness.php
+++ b/src/support/ConfigFreshness.php
@@ -11,12 +11,13 @@ use Throwable;
 
 /**
  * Detects external project config changes before a tool runs and refreshes
- * the long-lived server's in-process state (cached Info, ProjectConfig,
- * field, field-layout, and section memos). Proactive counterpart to Craft's
- * stale check:
- * the same configVersion comparison _acquireLock() uses to throw
- * StaleResourceException, done first so writes succeed and reads are fresh.
- * Fail-open by design: a failing probe must never block a tool call.
+ * the long-lived server's in-process state: cached Info, ProjectConfig, and
+ * the schema memos this plugin reads through (fields, field layouts,
+ * sections and entry types, sites, volumes, category groups, global sets).
+ * Proactive counterpart to Craft's stale check: the same configVersion
+ * comparison _acquireLock() uses to throw StaleResourceException, done first
+ * so writes succeed and reads are fresh. Fail-open by design: a failing
+ * probe must never block a tool call.
  *
  * @author Max van Essen <support@stimmt.digital>
  */
@@ -41,6 +42,9 @@ final class ConfigFreshness {
     }
 
     private static function applicable(): bool {
+        // Order matters: these short-circuits keep ensure()'s catch (and its
+        // Craft::warning call) unreachable under a null or stubbed app in
+        // unit tests.
         return Craft::$app !== null
             && method_exists(Craft::$app, 'getInfo')
             && Craft::$app->getIsInstalled();
@@ -53,13 +57,20 @@ final class ConfigFreshness {
     }
 
     private static function refresh(): void {
-        // Public API that nulls the cached Info model, so the next stale
-        // check compares against a fresh configVersion.
-        Craft::$app->getIsInstalled(true);
         PluginReloader::resetProjectConfig();
         Craft::$app->getFields()->refreshFields();
         PluginReloader::resetFieldLayoutsMemo();
         PluginReloader::resetEntriesMemos();
+        Craft::$app->getSites()->refreshSites();
+        Craft::$app->getGlobals()->reset();
+        PluginReloader::resetVolumesMemo();
+        PluginReloader::resetCategoriesMemo();
+
+        // Last on purpose: getIsInstalled(true) nulls the cached Info model,
+        // which is what makes the next stale check compare a fresh
+        // configVersion. If an earlier step ever throws, the version still
+        // mismatches on the next call and the refresh retries itself.
+        Craft::$app->getIsInstalled(true);
         Craft::info('Project config changed externally; refreshed in-process state', __METHOD__);
     }
 }

--- a/src/support/PluginReloader.php
+++ b/src/support/PluginReloader.php
@@ -67,6 +67,10 @@ final class PluginReloader {
         '_entryTypes' => null,
     ];
 
+    private const array FIELDS_SERVICE_LAYOUT_PROPERTIES = [
+        '_layouts' => null,
+    ];
+
     /**
      * Re-read the project config from YAML: clears the internal cache and
      * resets the ProjectConfig service. Adopted from PR #18 (dgaidula).
@@ -74,6 +78,25 @@ final class PluginReloader {
     public static function resetProjectConfig(): void {
         self::clearProjectConfigCache();
         Craft::$app->getProjectConfig()->reset();
+    }
+
+    /**
+     * Drop the Fields service's field-layout memo so the next layout lookup
+     * rebuilds fresh CustomField elements. Craft's own Fields::refreshFields()
+     * only nulls the raw field-records memo (_fields); the separate _layouts
+     * memo holds CustomField objects that resolve and clone their
+     * FieldInterface once per process (CustomField::getField() memoizes on
+     * first access), so a project-config-only field edit such as a changed
+     * instructions string never reaches it without this: the field record
+     * refreshes but every already-built layout keeps serving the old clone.
+     */
+    public static function resetFieldLayoutsMemo(): void {
+        $fields = Craft::$app->getFields();
+        $ref = new ReflectionClass($fields);
+
+        foreach (self::FIELDS_SERVICE_LAYOUT_PROPERTIES as $propertyName => $resetValue) {
+            $ref->getProperty($propertyName)->setValue($fields, $resetValue);
+        }
     }
 
     /**

--- a/src/support/PluginReloader.php
+++ b/src/support/PluginReloader.php
@@ -62,6 +62,34 @@ final class PluginReloader {
         Craft::$app->getCache()->delete('projectConfig:internal');
     }
 
+    private const array ENTRIES_SERVICE_PROPERTIES = [
+        '_sections' => null,
+        '_entryTypes' => null,
+    ];
+
+    /**
+     * Re-read the project config from YAML: clears the internal cache and
+     * resets the ProjectConfig service. Adopted from PR #18 (dgaidula).
+     */
+    public static function resetProjectConfig(): void {
+        self::clearProjectConfigCache();
+        Craft::$app->getProjectConfig()->reset();
+    }
+
+    /**
+     * Drop the Entries service's section and entry-type memos so the next
+     * read re-queries. Craft exposes no public sections refresh, hence the
+     * same reflection idiom as resetPluginsService().
+     */
+    public static function resetEntriesMemos(): void {
+        $entries = Craft::$app->getEntries();
+        $ref = new ReflectionClass($entries);
+
+        foreach (self::ENTRIES_SERVICE_PROPERTIES as $propertyName => $resetValue) {
+            $ref->getProperty($propertyName)->setValue($entries, $resetValue);
+        }
+    }
+
     /**
      * Reset the Plugins service to allow reloading.
      *

--- a/src/support/PluginReloader.php
+++ b/src/support/PluginReloader.php
@@ -29,6 +29,23 @@ final class PluginReloader {
         '_plugins' => [],
     ];
 
+    private const array ENTRIES_SERVICE_PROPERTIES = [
+        '_sections' => null,
+        '_entryTypes' => null,
+    ];
+
+    private const array FIELDS_SERVICE_LAYOUT_PROPERTIES = [
+        '_layouts' => null,
+    ];
+
+    private const array VOLUMES_SERVICE_PROPERTIES = [
+        '_volumes' => null,
+    ];
+
+    private const array CATEGORIES_SERVICE_PROPERTIES = [
+        '_groups' => null,
+    ];
+
     /**
      * Reload Composer's classmap to detect new plugin classes.
      *
@@ -61,15 +78,6 @@ final class PluginReloader {
     public static function clearProjectConfigCache(): void {
         Craft::$app->getCache()->delete('projectConfig:internal');
     }
-
-    private const array ENTRIES_SERVICE_PROPERTIES = [
-        '_sections' => null,
-        '_entryTypes' => null,
-    ];
-
-    private const array FIELDS_SERVICE_LAYOUT_PROPERTIES = [
-        '_layouts' => null,
-    ];
 
     /**
      * Re-read the project config from YAML: clears the internal cache and
@@ -110,6 +118,30 @@ final class PluginReloader {
 
         foreach (self::ENTRIES_SERVICE_PROPERTIES as $propertyName => $resetValue) {
             $ref->getProperty($propertyName)->setValue($entries, $resetValue);
+        }
+    }
+
+    /**
+     * Drop the Volumes service's memo; no public refresh exists.
+     */
+    public static function resetVolumesMemo(): void {
+        $volumes = Craft::$app->getVolumes();
+        $ref = new ReflectionClass($volumes);
+
+        foreach (self::VOLUMES_SERVICE_PROPERTIES as $propertyName => $resetValue) {
+            $ref->getProperty($propertyName)->setValue($volumes, $resetValue);
+        }
+    }
+
+    /**
+     * Drop the Categories service's group memo; no public refresh exists.
+     */
+    public static function resetCategoriesMemo(): void {
+        $categories = Craft::$app->getCategories();
+        $ref = new ReflectionClass($categories);
+
+        foreach (self::CATEGORIES_SERVICE_PROPERTIES as $propertyName => $resetValue) {
+            $ref->getProperty($propertyName)->setValue($categories, $resetValue);
         }
     }
 

--- a/src/support/SafeExecution.php
+++ b/src/support/SafeExecution.php
@@ -27,6 +27,8 @@ final class SafeExecution {
      * @throws ToolCallException
      */
     public static function run(callable $callback): mixed {
+        ConfigFreshness::ensure();
+
         try {
             return $callback();
         } catch (ToolCallException $e) {

--- a/src/tools/McpTools.php
+++ b/src/tools/McpTools.php
@@ -136,19 +136,16 @@ class McpTools {
             // 2. Refresh Craft's composer plugin info cache (re-reads plugins.php)
             $refreshResult = PluginReloader::refreshComposerPluginInfo();
 
-            // 3. Clear project config cache (required before reset)
-            PluginReloader::clearProjectConfigCache();
+            // 3. Reset project config to re-read from YAML
+            PluginReloader::resetProjectConfig();
 
-            // 4. Reset project config to re-read from YAML
-            Craft::$app->getProjectConfig()->reset();
-
-            // 5. Reset Plugins service internal caches
+            // 4. Reset Plugins service internal caches
             PluginReloader::resetPluginsService();
 
-            // 6. Reload Craft plugins
+            // 5. Reload Craft plugins
             Craft::$app->getPlugins()->loadPlugins();
 
-            // 7. Reset tool registry to re-collect tools
+            // 6. Reset tool registry to re-collect tools
             Mcp::resetToolRegistry();
 
             $summary = Mcp::getToolRegistry()->getSummary();

--- a/tests/Unit/Support/ConfigFreshnessTest.php
+++ b/tests/Unit/Support/ConfigFreshnessTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 3) . '/tests/Fixtures/CraftStub.php';
+
+use stimmt\craft\Mcp\support\ConfigFreshness;
+
+describe('ConfigFreshness', function () {
+    it('flags stale only when both versions are known and differ', function () {
+        expect(ConfigFreshness::isStale('abc', 'def'))->toBeTrue()
+            ->and(ConfigFreshness::isStale('abc', 'abc'))->toBeFalse()
+            ->and(ConfigFreshness::isStale(null, 'abc'))->toBeFalse()
+            ->and(ConfigFreshness::isStale('abc', null))->toBeFalse();
+    });
+
+    it('is a no-op without a full craft app', function () {
+        $original = Craft::$app;
+        Craft::$app = null;
+
+        ConfigFreshness::ensure();
+
+        Craft::$app = new class () {
+        };
+        ConfigFreshness::ensure();
+
+        Craft::$app = $original;
+        expect(true)->toBeTrue();
+    });
+});


### PR DESCRIPTION
## What

The long-lived stdio server boots Craft once, so external project config changes (a CLI migration, `project-config/apply`, a control panel edit) left it stale: config writes failed with `StaleResourceException`, and schema reads silently served outdated data until a manual `reload_mcp`. Reported with groundwork by @dgaidula in #18; this closes that story.

Every tool call now runs a cheap freshness guard first: one indexed single-row query comparing the DB's `info.configVersion` against the loaded value (the exact comparison Craft's own stale check uses). On mismatch, the server refreshes itself: cached `Info` model, ProjectConfig, and the memoized schema services this plugin reads through (fields and field layouts, sections and entry types, sites, volumes, category groups, global sets). Fail-open: a failing probe never blocks a tool call. HTTP requests boot fresh, so there the guard is a no-op costing one query.

## Why not the catch-and-retry from #18

Live testing showed two independent blockers with catching `StaleResourceException` and retrying:

- `tinker` executes through psysh, which renders exceptions as output text; the exception never reaches a catch block outside it.
- `ProjectConfig::reset()` alone does not refresh the `Info` model Craft caches on the Application, and the stale check compares against exactly that cached copy, so the retry re-fails identically.

Proactive detection sidesteps both: it runs before the tool body, and it flushes the cached Info through the public `getIsInstalled(true)`.

Two subtler gaps surfaced during live verification and are fixed here too: Craft's `Fields::refreshFields()` does not clear the separate `_layouts` memo (layout elements cache resolved field clones, so field edits stayed invisible to schema reads), and sites/volumes/categories/globals each memoize independently of `ProjectConfig::reset()`.

## Verify

- Long-lived session: run any config write via tinker, then `php craft project-config/touch && php craft project-config/apply` from another terminal, then repeat the write in the same session: it succeeds (previously: `StaleResourceException`).
- Same setup with a read: edit a field's instructions or rename a volume in project config externally and apply; a subsequent `describe_entry_schema`/`list_volumes` in the same session reflects the change immediately.
- Unit and static gates: `./vendor/bin/pest`, PHPStan, Rector, Pint (all green in CI).

## Notes

- New support class `ConfigFreshness` plus reset primitives on `PluginReloader`; two resets use the existing reflection idiom because Craft exposes no public refresh for those memos, and they are wrapped by the guard's fail-open catch.
- `reload_mcp` is unchanged and still useful for its actual job, reloading plugins.

Supersedes #18.
