### PR TITLE
feat: agent guidance for the content-writing upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Agent guidance now teaches the content-writing upgrade everywhere it speaks: the server instructions walk through schema discovery, natural keys, and the draft-first flow; the `create_entry_guide` and `bulk_entry_operations` prompts stop inviting payload guessing and lean on `describe_entry_schema` input shapes and drafts-as-safety-net; and a new `craft://guides/content-writing` resource serves the full payload contract on demand. HTTP connections additionally get a per-scope note in their instructions stating what the presenting token can and cannot do, and the `debug_content_issue` prompt stops recommending a tool that does not exist.
+
 ## [1.4.0-beta.2] - 2026-07-09
 
 ### Fixed

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -6,7 +6,7 @@ Resources use the `craft://` URI scheme, making it easy to reference specific da
 
 ## Schema Resources
 
-These resources expose your content architecture—sections, fields, and their configurations.
+These resources expose your content architecture: sections, fields, and their configurations.
 
 ### craft://schema/sections
 
@@ -293,6 +293,17 @@ Get information about all installed plugins.
 ## Content Resources
 
 These resources provide access to entry content within your sections.
+
+## Guide Resources
+
+Static reference guides agents can read on demand.
+
+### craft://guides/content-writing
+
+The full content-writing contract as markdown: the natural-key payload format, Matrix block shape, draft-first workflow, schema discovery with per-field input shapes, and how structured warnings and validation errors behave. The server instructions point agents here; the same content lives in [Content Writing](content-writing.md) for humans.
+
+**Example URI:** `craft://guides/content-writing`
+
 
 ### craft://entries/{section}
 

--- a/src/prompts/ContentPrompts.php
+++ b/src/prompts/ContentPrompts.php
@@ -140,7 +140,7 @@ I'm experiencing a content-related issue in Craft CMS and need help debugging it
 Please help me:
 1. Identify potential causes of this issue
 2. Suggest diagnostic steps to narrow down the problem
-3. Recommend tools to use (read_logs, get_last_error, get_file_problems)
+3. Recommend tools to use (read_logs, get_last_error, get_deprecations, explain_query)
 4. Provide possible solutions or workarounds
 5. Identify if this might be a configuration, data, or code issue
 

--- a/src/prompts/EntryPrompts.php
+++ b/src/prompts/EntryPrompts.php
@@ -66,12 +66,14 @@ I want to create entries in Craft CMS. Here's the section structure:
 {$guideJson}
 ```
 
-Please provide:
-1. An explanation of how to create entries in this section using the create_entry tool
-2. The required and optional fields for each entry type
-3. Example JSON payload(s) for the 'fields' parameter
-4. Any validation rules or constraints to be aware of
-5. Common pitfalls to avoid when creating entries
+Work with the payload format, not guesses:
+1. First call describe_entry_schema for this section (pass example with an existing entry id or slug to get a golden fixture); every field's 'input' shape is the exact payload it accepts
+2. Relations use natural keys ({"section": "...", "slug": "..."}, {"volume": "...", "filename": "..."}), never numeric ids; Matrix blocks are keyed objects with the entry-type handle as 'type'
+3. What get_entry returns is exactly what create_entry accepts, so an existing entry is a valid template
+4. Writes save as drafts by default: review via the returned cpEditUrl, then publish_entry makes them live
+5. Check the 'warnings' list on every write response; unresolvable keys become warnings, and validation failures return per-field errors
+
+Please walk me through creating an entry in this section following that flow, including a concrete fields payload built from the schema's input shapes.
 PROMPT);
         });
     }
@@ -112,7 +114,7 @@ I need to query entries from this Craft CMS section:
 ```
 
 Please provide guidance on:
-1. How to use the list_entries tool effectively for this section
+1. How to use the list_entries tool effectively for this section, including the full-text 'search' and multi-site 'site' parameters
 2. Available filter parameters based on the field types
 3. Pagination strategies for the {$entryCount} entries
 4. Performance optimization tips
@@ -158,11 +160,11 @@ Current state:
 - Entry types: {$entryTypes}
 
 Please help me understand:
-1. How to safely iterate through all entries using list_entries with pagination
-2. How to batch update entries using update_entry
-3. Error handling and rollback strategies
-4. Performance considerations for bulk operations
-5. Best practices to avoid data loss or corruption
+1. How to safely iterate through all entries using list_entries with pagination (and the search/site filters)
+2. How to batch update entries using update_entry: each write lands as a draft on top of the live entry, so nothing changes for visitors until publish_entry runs per entry
+3. How drafts double as the safety net: a wrong batch is discarded drafts, not corrupted live content; review spot checks via each response's cpEditUrl before publishing
+4. When duplicate_entry ("like X but change these") or copy_entry_to_site fits the job better than editing in place
+5. Reading the 'warnings' list on every write response, since unresolvable natural keys warn instead of failing the save
 
 What kind of bulk operation would you like to perform?
 PROMPT);

--- a/src/prompts/SchemaPrompts.php
+++ b/src/prompts/SchemaPrompts.php
@@ -65,7 +65,7 @@ Please describe:
 2. The entry types available and what content they represent
 3. The field configuration and data types
 4. Any relationships or complex field types
-5. Suggestions for querying or managing entries in this section
+5. Suggestions for querying or managing entries in this section (describe_entry_schema returns the write-ready per-field input shapes plus an optional golden-fixture example)
 PROMPT);
         });
     }
@@ -138,7 +138,7 @@ Please provide:
 2. The main content types and their purposes
 3. How different sections might relate to each other
 4. Any observations about the field structure and complexity
-5. Suggestions for content management workflows
+5. Suggestions for content management workflows (writes land as reviewable drafts by default; publish_entry makes them live)
 PROMPT);
     }
 

--- a/src/resources/GuideResources.php
+++ b/src/resources/GuideResources.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\resources;
+
+use Mcp\Capability\Attribute\McpResource;
+use stimmt\craft\Mcp\attributes\McpResourceMeta;
+use stimmt\craft\Mcp\enums\ResourceCategory;
+
+/**
+ * Static guides agents can pull on demand: the content-writing contract in
+ * full, without bloating the per-connection server instructions.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class GuideResources {
+    /**
+     * The content-writing payload contract.
+     */
+    #[McpResource(
+        uri: 'craft://guides/content-writing',
+        name: 'content-writing-guide',
+        description: 'The full content-writing contract for agents: payload format, natural keys, Matrix shape, draft-first workflow, schema discovery with input shapes, and structured feedback.',
+        mimeType: 'text/markdown',
+    )]
+    #[McpResourceMeta(category: ResourceCategory::CONTENT)]
+    public function contentWriting(): string {
+        return <<<'GUIDE'
+# Content Writing Contract
+
+Entry reads and writes share one format: what `get_entry` returns is exactly what `create_entry` and `update_entry` accept. Read an entry, tweak it, write it back.
+
+## Natural keys, no numeric IDs
+
+| Target | Key shape | Example |
+|--------|-----------|---------|
+| Entries | `{section, slug}` | `{"section": "pages", "slug": "about"}` |
+| Assets | `{volume, path?, filename}` | `{"volume": "images", "filename": "hero.jpg"}` |
+| Categories / Tags | `{group, slug}` | `{"group": "topics", "slug": "craft"}` |
+| Users | `{username}` | `{"username": "anna"}` |
+| Global sets | `{handle}` | `{"handle": "footer"}` |
+
+Relation fields take a list of these maps. Numeric IDs are also accepted, but reads always emit keys.
+
+## Matrix blocks
+
+Objects keyed by block id (`new1`, `new2`, ... for new blocks), each with the entry-type handle as `type`, optional `title` and `enabled`, and a `fields` map. Disabled blocks are preserved on round trips.
+
+## Discover the shape first
+
+Call `describe_entry_schema` for the section and entry type before writing. Pass `example` (an entry id or slug) to include a real entry as a golden fixture. Every field carries an `input` shape: the exact payload it accepts (natural-key format for relations, block types for Matrix, allowed values for options, columns for tables, link types for link fields, value types for scalars). When an `input` carries a `note` saying nested values pass through unchanged, send stored IDs or ref strings inside that field, not natural keys.
+
+## Draft-first writes
+
+- `create_entry` saves a draft; `update_entry` on a live entry creates a draft on top, leaving the live version untouched.
+- Responses carry `draftElementId` and a `cpEditUrl` deep link for human review in the control panel.
+- `publish_entry` applies the draft (canonical id when one pending draft exists, the specific `draftElementId` when several).
+- `delete_entry` soft-deletes to the trash; `duplicate_entry` clones as a draft with overrides; `copy_entry_to_site` copies values to another site's version as a draft.
+- Pass `mode: "live"` per call (or set the `entryWriteMode` setting) for immediate saves.
+
+## Structured feedback
+
+- Validation failures return per-field errors.
+- Unresolvable natural keys become warnings on an otherwise successful save; nothing is guessed, nothing is silently dropped.
+- Read the `warnings` list on every write response.
+
+## Multi-site
+
+Read and write tools accept a `site` handle parameter; natural keys resolve within that site.
+GUIDE;
+    }
+}

--- a/src/services/McpServerFactory.php
+++ b/src/services/McpServerFactory.php
@@ -50,7 +50,7 @@ class McpServerFactory {
                 name: 'Craft CMS MCP Server',
                 version: Mcp::getInstance()?->getVersion() ?? '1.0.0',
             )
-            ->setInstructions($this->getInstructions())
+            ->setInstructions($this->getInstructions($scope))
             ->setDiscovery(
                 basePath: dirname(__DIR__),
                 scanDirs: ['tools', 'prompts', 'resources'],
@@ -130,7 +130,24 @@ class McpServerFactory {
         }
     }
 
-    private function getInstructions(): string {
+    private function getInstructions(?Scope $scope = null): string {
+        return $this->baseInstructions() . $this->scopeNote($scope);
+    }
+
+    /**
+     * Per-connection scope note so the instructions are truthful for the
+     * token at hand; stdio (null scope) carries no note.
+     */
+    private function scopeNote(?Scope $scope): string {
+        return match ($scope) {
+            null => '',
+            Scope::ReadOnly => "\n\n## This Connection\n\nThis connection is READ-ONLY: no write, publish, or destructive tools are available, and the Writing Content section above does not apply here. Focus on browsing and inspection (`list_*`, `get_*`, `describe_entry_schema`).",
+            Scope::Content => "\n\n## This Connection\n\nThis connection has CONTENT scope: read everything, and write entries through the draft-first flow above (create, update, publish, delete, duplicate, copy to site). Code execution, raw SQL, GraphQL mutation, cache, and backup tools are not available.",
+            Scope::Full => "\n\n## This Connection\n\nThis connection has FULL scope: every tool the server exposes is available, including code execution and database tools. Prefer draft-mode writes and read-only queries unless the task requires more.",
+        };
+    }
+
+    private function baseInstructions(): string {
         return <<<'INSTRUCTIONS'
 This MCP server provides access to a Craft CMS installation.
 
@@ -140,12 +157,23 @@ This MCP server provides access to a Craft CMS installation.
 **Resources**: Read configuration, schema information, system state
 **Prompts**: Generate content, analyze structure, create entries
 
+## Writing Content (read this before create_entry/update_entry)
+
+1. Call `describe_entry_schema` for the section first; pass `example` (an entry id or slug) to get a real entry as a golden fixture. Every field carries an `input` shape describing the exact payload it accepts.
+2. The payload format is symmetric: what `get_entry` returns is exactly what `create_entry`/`update_entry` accept. Read one, tweak it, write it back.
+3. Use natural keys, never numeric ids: relations are `{"section": "...", "slug": "..."}`, assets `{"volume": "...", "filename": "..."}`, categories/tags `{"group": "...", "slug": "..."}`, users `{"username": "..."}`. Matrix blocks are keyed objects (`new1`, `new2`, ...) with the entry-type handle as `type`.
+4. Writes land as DRAFTS by default: the response carries `draftElementId` and a `cpEditUrl` deep link for human review; `publish_entry` makes them live. Nothing touches live content until published.
+5. Always read the `warnings` list on write responses: unresolvable natural keys become warnings, never guesses or silent drops. Validation failures return per-field errors.
+6. Multi-site installs: pass the `site` handle parameter; `copy_entry_to_site` moves content between sites.
+
+The full contract lives in the `craft://guides/content-writing` resource.
+
 ## Best Practices
 
 1. Use `list_*` tools to explore available data before making changes
 2. Use `get_*` tools to inspect specific items
-3. Check schema/fields before creating or updating entries
-4. Use read-only queries before mutations
+3. Use read-only queries before mutations
+4. Tools marked with a destructive annotation modify data or execute code; prefer draft-mode writes and review flows
 INSTRUCTIONS;
     }
 


### PR DESCRIPTION
## What

The tool descriptions learned the content-writing upgrade when it shipped; the other guidance surfaces had not. Now they speak the same language:

- **Server instructions** (sent to every client on initialize) walk through the read-then-write loop: `describe_entry_schema` first (with the golden-fixture `example`), the symmetric payload format, natural keys, draft-first writes with `cpEditUrl` review and `publish_entry`, checking `warnings`, and the `site` param.
- **HTTP connections get a per-scope note**: a readonly token's agent is told upfront it cannot write; content scope hears exactly which tool families it lacks; full scope is nudged toward draft-mode writes.
- **`create_entry_guide`** no longer invites the model to invent payloads; it teaches the schema-discovery flow and input shapes. **`bulk_entry_operations`** now presents drafts as the built-in safety net and points at `duplicate_entry`/`copy_entry_to_site`. **`query_entries_guide`** mentions the `search` and `site` params.
- **New resource `craft://guides/content-writing`**: the full payload contract as markdown, on demand, so the initialize instructions stay short.
- Swept the remaining prompts: `debug_content_issue` recommended a nonexistent `get_file_problems` tool (now real tools); the schema prompts point at `describe_entry_schema` and the draft flow where relevant.

## Verify

- `initialize` over stdio: instructions contain the Writing Content section and reference the guide resource (live-verified).
- `initialize` over HTTP with a readonly token: instructions carry the READ-ONLY connection note (live-verified).
- `resources/read` on `craft://guides/content-writing` returns the markdown contract (live-verified).
- Full gate green: pest 281, PHPStan, Rector, Pint.