### PR TITLE
feat: pending-drafts review queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `list_drafts` tool: the review queue for the draft-first workflow. Lists pending (non-provisional) entry drafts newest first, filterable by section, site, or creator, with the draft element id, canonical id, draft notes, and a control panel deep link per row. Available to `readonly` HTTP tokens, since reviewing is reading.
+- `review_pending_drafts` prompt: walks the queue conversationally (inspect via `get_entry`, approve via `publish_entry`, reject via `delete_entry`).
+
 ## [1.4.0-beta.3] - 2026-07-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Production safety defaults (`enabled` and `enableDangerousTools` off) now apply BEFORE the config file is read instead of only when no config file exists. Previously, creating `config/mcp.php` (as every quick start instructs) silently re-enabled dangerous tools in production; now only an explicit `'enableDangerousTools' => true` in the file does that.
+- `config/mcp.php` now supports Craft's multi-environment config convention (a `'*'` base merged with the current environment's block), which the configuration guide documented but the loader ignored.
+
 ### Added
 - `list_drafts` tool: the review queue for the draft-first workflow. Lists pending (non-provisional) entry drafts newest first, filterable by section, site, or creator, with the draft element id, canonical id, draft notes, and a control panel deep link per row. Available to `readonly` HTTP tokens, since reviewing is reading.
 - `review_pending_drafts` prompt: walks the queue conversationally (inspect via `get_entry`, approve via `publish_entry`, reject via `delete_entry`).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Craft MCP is an MCP (Model Context Protocol) server for Craft CMS. It gives AI assistants direct access to your installation's content, schema, and configuration: rather than describing your field layouts or Matrix setups by hand, the assistant queries them, writes reviewable draft content in a natural-key format, and inspects the system it is working in.
 
-It ships more than 50 specialized tools, 9 analysis prompts, and 12 data resources, served over stdio for local development and over HTTP with scoped bearer tokens for remote users.
+It ships more than 50 specialized tools, 10 analysis prompts, and 13 data resources, served over stdio for local development and over HTTP with scoped bearer tokens for remote users.
 
 ## Quick Start
 
@@ -52,7 +52,7 @@ Entry reads and writes share one payload format: relations as natural keys (`{"s
 
 | Category | Highlights |
 |----------|-----------|
-| [Content](docs/tools/content.md) | Entries (payload-format read/write, draft workflow, publish/duplicate/copy to site), schema discovery via `describe_entry_schema`, assets, categories, users, globals |
+| [Content](docs/tools/content.md) | Entries (payload-format read/write, draft workflow with a pending-drafts review queue, publish/duplicate/copy to site), schema discovery via `describe_entry_schema`, assets, categories, users, globals |
 | [System](docs/tools/system.md) | System info, config, logs, caches, routes, console commands |
 | [Database](docs/tools/database.md) | Schema inspection, table counts, read-only queries |
 | [Debugging](docs/tools/debugging.md) | Queue jobs, project config diff, deprecations, EXPLAIN, event handlers, and a Tinker tool for executing PHP in the Craft context |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Welcome to the Craft MCP documentation. This guide covers everything you need to
 
 Craft MCP is an MCP (Model Context Protocol) server that gives AI assistants direct access to your Craft CMS installation. Rather than manually describing your content architecture, field layouts, or database schema, your AI assistant can query this information directly, write reviewable draft content in a natural-key payload format, and inspect the system it is working in.
 
-The plugin provides more than 50 specialized tools, 9 analysis prompts, and 12 data resources, served over stdio for local development and over HTTP with per-user scoped bearer tokens for remote users.
+The plugin provides more than 50 specialized tools, 10 analysis prompts, and 13 data resources, served over stdio for local development and over HTTP with per-user scoped bearer tokens for remote users.
 
 ## Getting Started
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ return [
 ];
 ```
 
-This enables the MCP server with sensible defaults for development environments. The server will automatically disable dangerous tools when running in production.
+Production safety defaults are applied before this file is read: when `CRAFT_ENVIRONMENT` is `production`, `enabled` and `enableDangerousTools` both start out `false`. Values from `config/mcp.php` are then applied on top, key by key, and any key you set explicitly overrides the default for that key. In the minimal config above, only `enabled` is set, so in production the server turns on but `enableDangerousTools` stays at its safe default of `false`. To enable dangerous tools in production, set `'enableDangerousTools' => true` explicitly.
 
 ## Configuration Options
 
@@ -39,6 +39,14 @@ return [
         'tinker',
         'run_query',
     ],
+
+    // Disable specific prompts by name.
+    // Default: [] (no prompts disabled)
+    'disabledPrompts' => [],
+
+    // Disable specific resources by their URI (including resource templates).
+    // Default: [] (no resources disabled)
+    'disabledResources' => [],
 
     // Restrict MCP connections to specific IP addresses.
     // When empty, connections from any IP are allowed.
@@ -82,6 +90,8 @@ return [
 | `enabled` | `bool` | `false` (prod) / `true` (other) | Whether the MCP server accepts connections |
 | `enableDangerousTools` | `bool` | `false` (prod) / `true` (other) | Whether tools that modify data or execute code are available |
 | `disabledTools` | `array` | `[]` | List of tool names to disable regardless of other settings |
+| `disabledPrompts` | `array` | `[]` | List of prompt names to disable |
+| `disabledResources` | `array` | `[]` | List of resource URIs to disable |
 | `allowedIps` | `array` | `[]` | IP addresses allowed to connect (empty = all allowed) |
 | `logLevel` | `string` | `'error'` | Minimum log level for `storage/logs/mcp-server.log` |
 | `entryWriteMode` | `string` | `'draft'` | Since 1.4.0. Default save mode for entry writes: `'draft'` saves reviewable drafts, `'live'` saves immediately. Overridable per call via the `mode` param |
@@ -121,18 +131,18 @@ This approach keeps sensitive configuration out of version control and makes it 
 
 ### Automatic Environment Detection
 
-The plugin automatically adjusts its defaults based on the `CRAFT_ENVIRONMENT` environment variable:
+The plugin automatically adjusts its defaults based on the `CRAFT_ENVIRONMENT` environment variable, applied before `config/mcp.php` is read:
 
 | Setting | Production | Other Environments |
 |---------|------------|-------------------|
 | `enabled` | `false` | `true` |
 | `enableDangerousTools` | `false` | `true` |
 
-This means you can safely deploy the plugin to production without worrying about accidentally exposing the MCP server: it's disabled by default unless you explicitly enable it.
+These defaults apply whether or not `config/mcp.php` exists. Once the file is read, any key it sets explicitly overrides the default for that key; keys it doesn't mention keep the default shown above. This means you can safely deploy the plugin to production without worrying about accidentally exposing the MCP server or its dangerous tools: both stay off unless you explicitly turn them on.
 
 ## Multi-Environment Configuration
 
-For more complex setups, you can use Craft's multi-environment config pattern to define different settings for each environment:
+For more complex setups, `config/mcp.php` supports Craft's multi-environment config pattern: a top-level `'*'` key holding settings shared by every environment, merged with a block matching the current `CRAFT_ENVIRONMENT`. `Mcp::resolveEnvironmentConfig()` performs this merge; keys in the environment-specific block override the same key in `'*'`, and keys present in only one of the two pass through unchanged. A config file without a `'*'` key is treated as flat and applied as-is, with no per-environment interpretation.
 
 ```php
 <?php
@@ -163,7 +173,7 @@ return [
 ];
 ```
 
-This pattern allows you to grant full access during development, restricted access on staging for testing, and keep production locked down.
+This pattern allows you to grant full access during development, restricted access on staging for testing, and keep production locked down. As always, production safety defaults are applied first; the resolved `production` block above only needs to set what should differ from those defaults.
 
 ## Security Considerations
 
@@ -185,10 +195,16 @@ The following tools are classified as "dangerous" because they can modify data o
 
 | Tool | Risk Level | Description |
 |------|------------|-------------|
-| `tinker` | High | Executes arbitrary PHP code in your application context |
+| `tinker` | High | Executes arbitrary PHP code in your application context. Blocklist-based only, not a secure sandbox: it can be bypassed (e.g. `call_user_func`, variable functions) |
+| `execute_graphql` | High | Executes GraphQL queries and mutations, which can modify data |
 | `run_query` | Medium | Executes SQL queries (restricted to SELECT, but still exposes data) |
 | `create_entry` | Medium | Creates new entries in your content |
 | `update_entry` | Medium | Modifies existing entry content |
+| `publish_entry` | Medium | Applies a draft to its canonical entry, or enables a disabled entry |
+| `delete_entry` | Medium | Moves an entry to the trash |
+| `duplicate_entry` | Medium | Creates a new draft entry from an existing one |
+| `copy_entry_to_site` | Medium | Writes a draft on another site from an entry's field values |
+| `create_backup` | Medium | Creates files on the server filesystem |
 | `clear_caches` | Low | Can temporarily impact site performance |
 
 When `enableDangerousTools` is `false`, these tools are hidden from AI assistants entirely. You can also disable them individually using the `disabledTools` array if you want finer control.

--- a/docs/content-writing.md
+++ b/docs/content-writing.md
@@ -76,7 +76,7 @@ By default every write lands as a draft:
 - `publish_entry` applies the draft (pass the canonical entry id when there is a single pending draft, or the specific `draftElementId` when there are several).
 - Set `entryWriteMode: 'live'` in `config/mcp.php`, or pass `mode: "live"` per call, for immediate saves.
 
-The rest of the workflow: `delete_entry` soft-deletes to the trash (restorable), `duplicate_entry` clones as a draft with optional overrides ("like X but change these"), and `copy_entry_to_site` copies field values to another site's version as a draft for localization work.
+The rest of the workflow: `list_drafts` lists the pending review queue (newest first, filterable by section, site, or creator), `delete_entry` soft-deletes to the trash (restorable), `duplicate_entry` clones as a draft with optional overrides ("like X but change these"), and `copy_entry_to_site` copies field values to another site's version as a draft for localization work.
 
 ## Structured Feedback
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -179,7 +179,7 @@ class MyPluginTools
 }
 ```
 
-The `name` parameter defines how AI assistants will call the tool, while `description` helps them understand when to use it. Write clear, specific descriptions—they directly impact how well AI assistants choose the right tool for a task.
+The `name` parameter defines how AI assistants will call the tool, while `description` helps them understand when to use it. Write clear, specific descriptions: they directly impact how well AI assistants choose the right tool for a task.
 
 ## Tool Metadata
 
@@ -305,7 +305,7 @@ class CommerceTools implements ConditionalToolProvider
 }
 ```
 
-The `isAvailable()` method is called during tool registration. If it returns `false`, the entire class is skipped—none of its tools are registered.
+The `isAvailable()` method is called during tool registration. If it returns `false`, the entire class is skipped: none of its tools are registered.
 
 Common use cases:
 - Tools that require a specific plugin (Commerce, SEO, etc.)
@@ -720,6 +720,7 @@ class MyPluginResources
 | `SCHEMA` | Schema and structure information |
 | `CONFIG` | Configuration and settings |
 | `CONTENT` | Content data access |
+| `SYSTEM` | System status and diagnostic information |
 | `GENERAL` | Default category |
 
 ---

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -314,3 +314,5 @@ Prompts are available in AI assistants that support the MCP prompts capability. 
 **Cursor:** Access prompts through the Composer's MCP integration panel.
 
 Each prompt gathers fresh data from your Craft installation at the time it's invoked, ensuring you always get current information for analysis.
+
+Individual prompts can be disabled by name via the `disabledPrompts` option in `config/mcp.php`. See the [Configuration Guide](configuration.md#configuration-options).

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -188,6 +188,22 @@ bulk_entry_operations section="news"
 
 ---
 
+### review_pending_drafts
+
+Walk through the pending entry drafts awaiting review: inspect each one, publish it, or reject it. Embeds the live count of non-provisional drafts and drives the list_drafts, get_entry, publish_entry, and delete_entry loop, sharing each draft's cpEditUrl for control panel review.
+
+**Arguments:**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `section` | No | Limit the queue to one section handle |
+
+**Example:**
+
+```
+review_pending_drafts section="pages"
+```
+
 ## Schema Exploration
 
 These prompts help you understand your content architecture and field configurations.
@@ -250,7 +266,7 @@ This is useful for understanding field dependencies before making changes, or fo
 
 ### explore_content_model
 
-Get a comprehensive overview of your entire content model—all sections, entry types, and their field relationships.
+Get a comprehensive overview of your entire content model: all sections, entry types, and their field relationships.
 
 **Parameters:** None
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -127,12 +127,12 @@ create_entry_guide section="blog" entryType="article"
 
 **What it provides:**
 
-The prompt gathers the section's complete field layout and presents:
+The prompt gathers the section's structure and walks the schema-discovery flow:
 
-- Required vs optional fields for each entry type
-- Field types and validation constraints
-- Example JSON payloads for the `create_entry` tool
-- Common pitfalls to avoid
+- Calling `describe_entry_schema` first (with a golden-fixture `example`) so every field's `input` shape is known, not guessed
+- Natural-key payloads for relations and the Matrix block format
+- The draft-first flow: review via `cpEditUrl`, publish via `publish_entry`
+- Reading `warnings` and per-field validation errors on write responses
 
 This is particularly useful when you need to create entries programmatically and want to understand the exact field structure.
 
@@ -181,10 +181,10 @@ bulk_entry_operations section="news"
 
 **What it provides:**
 
-- Safe iteration patterns using pagination
-- Batch update strategies
-- Error handling and rollback considerations
-- Performance tips for large datasets
+- Safe iteration patterns using pagination and the search/site filters
+- Batch updates that land as drafts, so live content is untouched until each `publish_entry`
+- Drafts as the safety net: a wrong batch is discarded drafts, not corrupted content
+- When `duplicate_entry` or `copy_entry_to_site` fits better than editing in place
 
 ---
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -374,6 +374,8 @@ Get a specific entry by its section and slug, including all custom field values.
 }
 ```
 
+This is a lighter, raw view of the entry: relation fields serialize as plain numeric id arrays (or `{count, truncated}` once there are more than 10), not the natural-key payload format used by `get_entry` and the entry write tools. Use this resource for a quick read; use `get_entry` when you need the payload-compatible shape described in the [Content Writing guide](content-writing.md).
+
 ---
 
 ### craft://entries/{section}/stats
@@ -431,3 +433,7 @@ When a resource can't be found, it returns an error object:
 ```
 
 This allows AI assistants to gracefully handle missing data and provide helpful feedback.
+
+## Disabling Resources
+
+Individual resources, including resource templates, can be disabled by URI via the `disabledResources` option in `config/mcp.php`. See the [Configuration Guide](configuration.md#configuration-options).

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -300,7 +300,7 @@ Static reference guides agents can read on demand.
 
 ### craft://guides/content-writing
 
-The full content-writing contract as markdown: the natural-key payload format, Matrix block shape, draft-first workflow, schema discovery with per-field input shapes, and how structured warnings and validation errors behave. The server instructions point agents here; the same content lives in [Content Writing](content-writing.md) for humans.
+The full content-writing contract as markdown: the natural-key payload format, Matrix block shape, draft-first workflow, schema discovery with per-field input shapes, and how structured warnings and validation errors behave. The server instructions point agents here; it is served directly from the shipped [Content Writing](content-writing.md) page, so agents and humans always read the same contract.
 
 **Example URI:** `craft://guides/content-writing`
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Craft MCP provides 55 tools that give AI assistants comprehensive access to your Craft installation. This page provides a quick reference to all available tools, organized by category.
+Craft MCP provides 56 tools that give AI assistants comprehensive access to your Craft installation. This page provides a quick reference to all available tools, organized by category.
 
 ## Tool Categories
 
@@ -8,7 +8,7 @@ The tools are organized into logical categories based on what they do:
 
 | Category | Tools | Description |
 |----------|-------|-------------|
-| [Content](content.md) | 14 | Query and manage entries (payload-format read/write, draft workflow, publish/duplicate/copy to site), assets, categories, users, and global sets |
+| [Content](content.md) | 15 | Query and manage entries (payload-format read/write, draft workflow, publish/duplicate/copy to site), assets, categories, users, and global sets |
 | [System](system.md) | 7 | Access configuration, logs, caches, routes, and system information |
 | [Database](database.md) | 4 | Inspect database schema, run queries, and explore table structures |
 | [Debugging](debugging.md) | 7 | Monitor queue jobs, project config changes, deprecations, and more |
@@ -33,6 +33,7 @@ These tools let AI assistants work with your Craft content:
 | `get_entry` | Get one entry by id or slug, in the payload format that `create_entry`/`update_entry` accept as `fields` |
 | `create_entry` | Create an entry from payload-format `fields`; saves as a draft by default |
 | `update_entry` | Update an entry by id from payload-format `fields`; drafts on top of a live entry by default |
+| `list_drafts` | List pending drafts awaiting review, newest first, with publish ids and control panel links |
 | `publish_entry` | Apply a pending draft to its canonical entry, or enable a disabled live entry |
 | `delete_entry` | Soft-delete an entry to the trash, restorable from the control panel |
 | `duplicate_entry` | Duplicate an entry as an unpublished draft, with optional field overrides |

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -8,11 +8,11 @@ The tools are organized into logical categories based on what they do:
 
 | Category | Tools | Description |
 |----------|-------|-------------|
-| [Content](content.md) | 15 | Query and manage entries (payload-format read/write, draft workflow, publish/duplicate/copy to site), assets, categories, users, and global sets |
+| [Content](content.md) | 16 | Query and manage entries (payload-format read/write, draft workflow, publish/duplicate/copy to site), assets, categories, users, and global sets |
 | [System](system.md) | 7 | Access configuration, logs, caches, routes, and system information |
 | [Database](database.md) | 4 | Inspect database schema, run queries, and explore table structures |
 | [Debugging](debugging.md) | 7 | Monitor queue jobs, project config changes, deprecations, and more |
-| Schema | 5 | Inspect sections, fields, volumes, and plugins; discover an entry type's write schema |
+| Schema | 4 | Inspect sections, fields, and plugins; discover an entry type's write schema |
 | [Multi-Site](multisite.md) | 3 | Manage and inspect multi-site configurations |
 | [GraphQL](graphql.md) | 4 | Query schemas, tokens, and execute GraphQL operations |
 | [Backup](backup.md) | 2 | List and create database backups |
@@ -41,7 +41,8 @@ These tools let AI assistants work with your Craft content:
 | `list_assets` | Browse assets with filtering by volume, folder, filename, and kind |
 | `get_asset` | Get detailed asset information including dimensions, file size, and metadata |
 | `list_asset_folders` | List folder structure within a specific asset volume |
-| `list_categories` | Query categories by group with hierarchy and custom field values |
+| `list_volumes` | Inspect asset volume configurations and filesystem settings |
+| `list_categories` | Query categories by group |
 | `list_users` | List Craft users with filtering by group, status, and email |
 | `list_globals` | List all global sets with their current field values |
 
@@ -53,7 +54,6 @@ These tools help AI assistants understand your content architecture:
 |------|-------------|
 | `list_sections` | Get all sections with their entry types, handles, and field layouts |
 | `list_fields` | List all custom fields with types, settings, and group assignments |
-| `list_volumes` | Inspect asset volume configurations and filesystem settings |
 | `list_plugins` | Get installed plugins with versions, handles, and enabled status |
 | `describe_entry_schema` | Describe a section/entry type's fields, kinds, and per-field input shapes, for use with `create_entry`/`update_entry` |
 

--- a/docs/tools/backup.md
+++ b/docs/tools/backup.md
@@ -1,6 +1,6 @@
 # Backup Tools
 
-Backup tools help manage database backups in your Craft installation. You can list existing backups and create new ones—useful for snapshotting the database before making significant changes.
+Backup tools help manage database backups in your Craft installation. You can list existing backups and create new ones, useful for snapshotting the database before making significant changes.
 
 ## Database Backups
 
@@ -106,4 +106,4 @@ Common failure reasons:
 - **Before migrations**: Create a backup before running `project-config/apply` or database migrations
 - **Before bulk operations**: Back up before mass entry updates or deletions
 - **Regular cleanup**: Old backups accumulate; periodically remove backups you no longer need
-- **External storage**: For production, copy important backups to external storage—the `storage/backups` directory shouldn't be your only copy
+- **External storage**: For production, copy important backups to external storage, the `storage/backups` directory shouldn't be your only copy

--- a/docs/tools/commerce.md
+++ b/docs/tools/commerce.md
@@ -1,6 +1,6 @@
 # Commerce Tools
 
-Commerce tools provide access to Craft Commerce data—products, orders, and their associated configurations. These tools are only available when Craft Commerce is installed and enabled.
+Commerce tools provide access to Craft Commerce data, products, orders, and their associated configurations. These tools are only available when Craft Commerce is installed and enabled.
 
 > **Note:** These tools are conditionally registered. If Commerce isn't installed, they won't appear in the tool list.
 

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -16,7 +16,7 @@ List entries. Filter by section, type, status, site handle, and full-text search
 |------|------|---------|-------------|
 | `section` | string | null | Filter by section handle (e.g., "news", "blog") |
 | `type` | string | null | Filter by entry type handle |
-| `status` | string | null | Filter by status: "live", "pending", "disabled", or "any" |
+| `status` | string | null | Filter by status: "live", "pending", "expired", "disabled", or "any" |
 | `site` | string | null | Site handle to query and read fields from (defaults to the primary site) |
 | `search` | string | null | Full-text search term |
 | `limit` | int | 20 | Maximum number of entries to return |
@@ -517,7 +517,7 @@ Query assets with filtering by volume, file type, or filename.
 | `kind` | string | null | Filter by file kind: "image", "video", "pdf", "document", etc. |
 | `filename` | string | null | Filter by filename (partial match) |
 | `folderId` | int | null | Filter by specific folder ID |
-| `limit` | int | 20 | Maximum assets to return |
+| `limit` | int | 50 | Maximum assets to return |
 | `offset` | int | 0 | Number of assets to skip |
 
 **Examples:**
@@ -539,6 +539,8 @@ list_assets kind="pdf"
 {
   "count": 10,
   "total": 234,
+  "limit": 50,
+  "offset": 0,
   "assets": [
     {
       "id": 456,
@@ -549,7 +551,10 @@ list_assets kind="pdf"
       "width": 1920,
       "height": 1080,
       "url": "https://example.com/uploads/hero-image.jpg",
-      "volumeHandle": "images"
+      "volumeId": 3,
+      "folderId": 12,
+      "dateCreated": "2024-01-15 10:30:00",
+      "dateModified": "2024-01-15 14:22:00"
     }
   ]
 }
@@ -604,13 +609,14 @@ get_asset id=456
 
 ### list_asset_folders
 
-List the folder structure within a specific asset volume. Useful for understanding how assets are organized.
+List the folder structure within a specific asset volume, or across every volume's root folders when `volume` is omitted.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `volume` | string | Yes | Volume handle |
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `volume` | string | null | Volume handle; when omitted, lists root folders across every volume (in which case `parentId` is ignored) |
+| `parentId` | int | null | List this folder's children instead of the volume's root folder; only used when `volume` is also given |
 
 **Example:**
 
@@ -622,18 +628,53 @@ list_asset_folders volume="images"
 
 ```json
 {
-  "volume": "images",
   "count": 5,
   "folders": [
     {
       "id": 1,
       "name": "Banners",
-      "path": "banners"
+      "path": "banners",
+      "volumeId": 3,
+      "parentId": null
     },
     {
       "id": 2,
       "name": "Team Photos",
-      "path": "team-photos"
+      "path": "team-photos",
+      "volumeId": 3,
+      "parentId": null
+    }
+  ]
+}
+```
+
+---
+
+### list_volumes
+
+List all asset volumes (storage locations) configured in Craft, including filesystem type and public URL.
+
+**Parameters:** None
+
+**Example:**
+
+```
+list_volumes
+```
+
+**Response:**
+
+```json
+{
+  "count": 2,
+  "volumes": [
+    {
+      "id": 1,
+      "handle": "images",
+      "name": "Images",
+      "type": "craft\\fs\\Local",
+      "hasUrls": true,
+      "rootUrl": "https://example.com/uploads"
     }
   ]
 }
@@ -647,14 +688,14 @@ Categories in Craft are hierarchical taxonomies for organizing content. Each cat
 
 ### list_categories
 
-List categories within a specific category group, including their hierarchy and custom field values.
+List categories. Filter by group handle; when omitted, returns categories across all groups.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `group` | string | Yes | Category group handle |
-| `limit` | int | No | Maximum categories to return (default: 100) |
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `group` | string | null | Category group handle |
+| `limit` | int | 100 | Maximum categories to return |
 
 **Example:**
 
@@ -667,31 +708,30 @@ list_categories group="topics"
 ```json
 {
   "count": 8,
-  "group": "topics",
   "categories": [
     {
       "id": 10,
       "title": "Technology",
       "slug": "technology",
       "level": 1,
-      "parentId": null,
-      "fields": {
-        "description": "Articles about technology"
-      }
+      "groupId": 3,
+      "groupHandle": "topics",
+      "url": "https://example.com/topics/technology"
     },
     {
       "id": 11,
       "title": "Software",
       "slug": "software",
       "level": 2,
-      "parentId": 10,
-      "fields": {}
+      "groupId": 3,
+      "groupHandle": "topics",
+      "url": "https://example.com/topics/technology/software"
     }
   ]
 }
 ```
 
-The `level` and `parentId` fields indicate the category's position in the hierarchy.
+`level` indicates the category's depth within its group's hierarchy. The response doesn't include a parent id or custom field values.
 
 ---
 
@@ -710,8 +750,7 @@ List Craft users with optional filtering by group, status, or email.
 | `group` | string | null | Filter by user group handle |
 | `status` | string | null | Filter by status: "active", "pending", "suspended" |
 | `email` | string | null | Filter by email (partial match) |
-| `limit` | int | 20 | Maximum users to return |
-| `offset` | int | 0 | Number of users to skip |
+| `limit` | int | 50 | Maximum users to return |
 
 **Examples:**
 
@@ -731,17 +770,17 @@ list_users group="admins" status="active"
 ```json
 {
   "count": 5,
-  "total": 12,
   "users": [
     {
       "id": 1,
-      "email": "admin@example.com",
       "username": "admin",
+      "email": "admin@example.com",
       "fullName": "Site Administrator",
+      "admin": true,
       "status": "active",
       "groups": ["admins", "editors"],
-      "dateCreated": "2023-06-01T00:00:00+00:00",
-      "lastLoginDate": "2024-01-15T10:30:00+00:00"
+      "lastLoginDate": "2024-01-15 10:30:00",
+      "dateCreated": "2023-06-01 00:00:00"
     }
   ]
 }

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -329,6 +329,30 @@ Relation fields carry both a top-level `target` (the related element type and it
 
 ---
 
+### list_drafts
+
+List pending (non-provisional) entry drafts awaiting review, newest first. This is the review queue for the draft-first workflow: everything create_entry, update_entry, and duplicate_entry produce lands here until it is published or discarded.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `section` | string | No | Filter by section handle |
+| `site` | string | No | Filter by site handle |
+| `creator` | string | No | Filter by the draft creator's username or email |
+| `limit` | int | No | Maximum drafts to return (default: 20) |
+| `offset` | int | No | Offset for pagination (default: 0) |
+
+**Response rows:** `draftElementId` (what publish_entry and get_entry accept), `canonicalId` (the live entry it belongs to; equals the draft for brand-new entries, flagged by `isNewEntry`), `title`, `section`, `type`, `site`, `creator`, `notes`, `dateUpdated`, and a `cpEditUrl` deep link for reviewing the draft in the control panel.
+
+**Example:**
+
+```
+list_drafts section="pages" creator="anna@site.nl"
+```
+
+The `review_pending_drafts` prompt walks through this queue conversationally: inspect, publish, or reject each draft.
+
 ### publish_entry
 
 Publish an entry: applies a draft (by draft element id, or a canonical id with exactly one pending draft) to its canonical entry, or enables a disabled live entry.

--- a/docs/tools/database.md
+++ b/docs/tools/database.md
@@ -32,7 +32,7 @@ get_database_info
 }
 ```
 
-The `tablePrefix` is particularly important—most Craft installations use `craft_` as the prefix, which means the `entries` table is actually named `craft_entries`. You'll need to include this prefix in your SQL queries.
+The `tablePrefix` is particularly important: most Craft installations use `craft_` as the prefix, which means the `entries` table is actually named `craft_entries`. You'll need to include this prefix in your SQL queries.
 
 ---
 
@@ -144,7 +144,7 @@ get_table_counts
 }
 ```
 
-This is often the first thing to check when getting familiar with a new Craft installation—it immediately tells you whether you're dealing with a small portfolio site or a large content-heavy application.
+This is often the first thing to check when getting familiar with a new Craft installation: it immediately tells you whether you're dealing with a small portfolio site or a large content-heavy application.
 
 ---
 
@@ -170,7 +170,7 @@ Execute read-only SQL queries against your database. This is classified as a dan
 The tool enforces several safety measures:
 
 - Only `SELECT` queries are allowed
-- Blocked keywords: `INSERT`, `UPDATE`, `DELETE`, `DROP`, `TRUNCATE`, `ALTER`, `CREATE`, `GRANT`, `REVOKE`
+- Blocked keywords: `INSERT`, `UPDATE`, `DELETE`, `DROP`, `TRUNCATE`, `ALTER`, `CREATE`, `GRANT`, `REVOKE`, `INTO OUTFILE`
 - A `LIMIT` clause is automatically added if your query doesn't include one
 
 **Examples:**

--- a/docs/tools/debugging.md
+++ b/docs/tools/debugging.md
@@ -1,6 +1,6 @@
 # Debugging Tools
 
-Debugging tools help AI assistants investigate issues in your Craft installation. From queue job failures to project config drift to deprecation warnings, these tools surface the diagnostic information needed to understand what's happening—and what's gone wrong.
+Debugging tools help AI assistants investigate issues in your Craft installation. From queue job failures to project config drift to deprecation warnings, these tools surface the diagnostic information needed to understand what's happening, and what's gone wrong.
 
 ## Queue Jobs
 
@@ -64,7 +64,7 @@ get_queue_jobs status="reserved"
 }
 ```
 
-The `counts` object in every response gives you a quick overview of the entire queue state, regardless of which status you filtered by. This makes it easy to spot problems—if you see failed jobs piling up, something needs attention.
+The `counts` object in every response gives you a quick overview of the entire queue state, regardless of which status you filtered by. This makes it easy to spot problems: if you see failed jobs piling up, something needs attention.
 
 ---
 
@@ -170,7 +170,7 @@ get_deprecations limit=20
 }
 ```
 
-Database deprecations are particularly useful because they include the exact file and line number where the deprecated code was called. This makes fixing them straightforward—you know exactly where to look.
+Database deprecations are particularly useful because they include the exact file and line number where the deprecated code was called. This makes fixing them straightforward: you know exactly where to look.
 
 ---
 
@@ -188,7 +188,7 @@ Run MySQL or PostgreSQL's `EXPLAIN` command on a SELECT query to understand how 
 |------|------|----------|-------------|
 | `sql` | string | Yes | The SELECT query to analyze |
 
-**Security:** This tool has the same restrictions as `run_query`—only SELECT statements are allowed, and dangerous keywords are blocked.
+**Security:** This tool has the same restrictions as `run_query`: only SELECT statements are allowed, and dangerous keywords are blocked.
 
 **Example:**
 
@@ -229,7 +229,7 @@ Key things to look for in the output:
 
 ## Environment
 
-Environment settings affect how Craft behaves—dev mode, queue settings, caching, and more. This tool surfaces those settings without exposing sensitive values like database credentials.
+Environment settings affect how Craft behaves: dev mode, queue settings, caching, and more. This tool surfaces those settings without exposing sensitive values like database credentials.
 
 ### get_environment
 
@@ -279,7 +279,7 @@ get_environment
 }
 ```
 
-This tool is particularly useful for debugging issues that might be environment-specific—like why template caching works in production but not locally, or why file uploads are failing due to PHP limits.
+This tool is particularly useful for debugging issues that might be environment-specific, like why template caching works in production but not locally, or why file uploads are failing due to PHP limits.
 
 ---
 
@@ -373,13 +373,17 @@ Execute PHP code within your Craft application context. This is a powerful tool 
 
 **Security restrictions:**
 
-For safety, certain operations are blocked:
+For safety, code is checked against a pattern blocklist before it runs:
 
-- **Shell commands**: `exec`, `shell_exec`, `system`, `passthru`, `proc_open`
-- **File writes**: `file_put_contents`, `fwrite`, `fputs`
-- **Dangerous functions**: `eval` (to prevent nested evaluation)
+- **Shell and process execution**: `exec`, `shell_exec`, `system`, `passthru`, `popen`, `proc_open`
+- **Process control**: `pcntl_*`, `posix_*` functions
+- **File writes and deletes**: `unlink`, `rmdir`, `file_put_contents`, `fwrite`, `rename`, `copy`, `move_uploaded_file`
+- **Dangerous functions**: `eval`, `create_function`
+- **Unbounded output-buffer teardown**: a `while (ob_get_level() ...)` loop is blocked, since the server's stdout shield buffer can't be removed and such a loop would never end
 
 The code is parsed using PsySH's CodeCleaner before execution.
+
+**This is not a secure sandbox.** The blocklist can be bypassed (for example via `call_user_func` or variable functions), so only enable `tinker` in trusted environments; treat it as a development convenience, not isolation.
 
 **Examples:**
 
@@ -433,7 +437,7 @@ Errors are displayed with a `!` prefix in red, followed by a location hint when 
 
 ```
 > exec('ls')
-! SecurityError: Code contains blocked function. Shell commands, file writes, and eval are not allowed.
+! SecurityError: Code contains a blocked pattern. Shell commands, file writes, eval, and unbounded output-buffer teardown loops are not allowed.
 ```
 
 **Available in context:**

--- a/docs/tools/graphql.md
+++ b/docs/tools/graphql.md
@@ -1,6 +1,6 @@
 # GraphQL Tools
 
-GraphQL tools provide access to Craft's built-in GraphQL API. You can inspect schemas, list API tokens, and execute queries directly—useful for debugging GraphQL integrations or exploring what data is available through the API.
+GraphQL tools provide access to Craft's built-in GraphQL API. You can inspect schemas, list API tokens, and execute queries directly, useful for debugging GraphQL integrations or exploring what data is available through the API.
 
 ## Schemas
 
@@ -111,7 +111,7 @@ get_graphql_schema uid="a1b2c3d4-..."
 }
 ```
 
-The `sdl` field contains the complete schema definition—this can be quite large for schemas with broad access. The `sdlLength` field tells you how many characters the SDL contains.
+The `sdl` field contains the complete schema definition, this can be quite large for schemas with broad access. The `sdlLength` field tells you how many characters the SDL contains.
 
 ---
 
@@ -175,7 +175,7 @@ execute_graphql query="{ entries { title } }" schemaId=2
 }
 ```
 
-Note that GraphQL errors are returned in the `errors` field while `success` remains true—this matches standard GraphQL behavior where partial results can be returned alongside errors.
+Note that GraphQL errors are returned in the `errors` field while `success` remains true, this matches standard GraphQL behavior where partial results can be returned alongside errors.
 
 ---
 
@@ -185,7 +185,7 @@ GraphQL tokens are API keys that authenticate requests and associate them with a
 
 ### list_graphql_tokens
 
-List all GraphQL tokens with their associated schemas. Token values are not exposed for security—only metadata about the tokens.
+List all GraphQL tokens with their associated schemas. Token values are not exposed for security, only metadata about the tokens.
 
 **Parameters:** None
 

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -1,6 +1,6 @@
 # Self-Awareness Tools
 
-Self-awareness tools let AI assistants understand the MCP plugin itself—its configuration, available tools, and runtime status. This is useful for discovering capabilities and troubleshooting integration issues.
+Self-awareness tools let AI assistants understand the MCP plugin itself, its configuration, available tools, and runtime status. This is useful for discovering capabilities and troubleshooting integration issues.
 
 ## Plugin Information
 
@@ -59,7 +59,7 @@ get_mcp_info
 Key sections:
 
 - **status**: Shows whether the plugin and dangerous tools are enabled, plus the current environment
-- **tools.bySource**: Shows where tools come from—`craft-mcp` for built-in tools, other sources for plugin-provided tools
+- **tools.bySource**: Shows where tools come from, `craft-mcp` for built-in tools, other sources for plugin-provided tools
 - **tools.byCategory**: Tool count by functional category
 - **tools.dangerous**: Count of tools marked as dangerous
 - **tools.errors**: Any errors encountered during tool registration
@@ -124,7 +124,7 @@ list_mcp_tools
 }
 ```
 
-Tools are sorted by source, then category, then name. The `enabled` field reflects both the dangerous tools setting and the `disabledTools` configuration—a tool shows as disabled if either condition prevents it from running.
+Tools are sorted by source, then category, then name. The `enabled` field reflects both the dangerous tools setting and the `disabledTools` configuration, a tool shows as disabled if either condition prevents it from running.
 
 ---
 

--- a/docs/tools/multisite.md
+++ b/docs/tools/multisite.md
@@ -4,7 +4,7 @@ Multi-site tools help AI assistants understand and work with Craft's multi-site 
 
 ## Sites
 
-Sites in Craft represent distinct front-end experiences—different domains, languages, or content variations. Each site belongs to a site group and has its own base URL, language, and enabled status.
+Sites in Craft represent distinct front-end experiences, different domains, languages, or content variations. Each site belongs to a site group and has its own base URL, language, and enabled status.
 
 ### list_sites
 
@@ -126,7 +126,7 @@ get_site handle="german"
 
 ## Site Groups
 
-Site groups organize related sites together. Sites within the same group can share content through Craft's propagation settings—when you create an entry in one site, it can automatically propagate to other sites in the same group.
+Site groups organize related sites together. Sites within the same group can share content through Craft's propagation settings, when you create an entry in one site, it can automatically propagate to other sites in the same group.
 
 ### list_site_groups
 
@@ -164,4 +164,4 @@ list_site_groups
 }
 ```
 
-The `siteHandles` array shows which sites belong to each group. This is useful for understanding content propagation—entries created in any site within a group can be configured to automatically appear in the other sites in that group.
+The `siteHandles` array shows which sites belong to each group. This is useful for understanding content propagation, entries created in any site within a group can be configured to automatically appear in the other sites in that group.

--- a/docs/tools/system.md
+++ b/docs/tools/system.md
@@ -208,7 +208,7 @@ If no errors exist in the logs, the response will indicate `"found": false`.
 
 ## Caching
 
-Craft uses several caching layers to improve performance. Sometimes you need to clear these caches—after template changes, during debugging, or when troubleshooting stale data issues.
+Craft uses several caching layers to improve performance. Sometimes you need to clear these caches: after template changes, during debugging, or when troubleshooting stale data issues.
 
 ### clear_caches
 
@@ -340,7 +340,7 @@ list_console_commands
 
 ## Schema Information
 
-These tools help AI assistants understand your content architecture—the sections, fields, asset volumes, and plugins that define how your Craft installation is structured.
+These tools help AI assistants understand your content architecture: the sections, fields, and plugins that define how your Craft installation is structured.
 
 ### list_plugins
 
@@ -354,7 +354,7 @@ List all installed plugins with their version numbers, enabled status, and devel
 
 ### list_sections
 
-Get all sections and their entry types. This reveals the content structure of your site—which sections exist, whether they're channels, structures, or singles, and what entry types are available in each.
+Get all sections and their entry types. This reveals the content structure of your site: which sections exist, whether they're channels, structures, or singles, and what entry types are available in each.
 
 **Parameters:** None
 
@@ -369,13 +369,3 @@ List all custom fields defined in your Craft installation. Each field includes i
 **Parameters:** None
 
 **Response includes:** Field handle, name, type, group assignment, and field-specific settings.
-
----
-
-### list_volumes
-
-Get information about asset volumes—where files are stored and how they're accessed. This includes filesystem configuration and public URL settings.
-
-**Parameters:** None
-
-**Response includes:** Volume handle, name, filesystem type, and base URL.

--- a/src/Mcp.php
+++ b/src/Mcp.php
@@ -226,15 +226,20 @@ class Mcp extends BasePlugin {
     }
 
     /**
-     * Apply config/mcp.php overrides to settings.
+     * Apply config/mcp.php overrides to settings. Production safety defaults
+     * are applied FIRST and unconditionally, so creating a config file never
+     * silently re-enables dangerous tools in production; only an explicit
+     * key in the file overrides them.
      */
     private static function applyConfigOverrides(Settings $settings): Settings {
+        $settings = self::applyProductionDefaults($settings);
+
         /** @var Path $pathService */
         $pathService = Craft::$app->getPath();
         $configPath = $pathService->getConfigPath() . '/mcp.php';
 
         if (!file_exists($configPath)) {
-            return self::applyProductionDefaults($settings);
+            return $settings;
         }
 
         $config = require $configPath;
@@ -242,7 +247,7 @@ class Mcp extends BasePlugin {
             return $settings;
         }
 
-        foreach ($config as $key => $value) {
+        foreach (self::resolveEnvironmentConfig($config, self::environment()) as $key => $value) {
             if (property_exists($settings, $key)) {
                 $settings->$key = $value;
             }
@@ -252,12 +257,32 @@ class Mcp extends BasePlugin {
     }
 
     /**
-     * Apply safe defaults when no config file exists.
+     * Craft's multi-environment config convention: a file with a '*' key is
+     * environment-nested; the '*' base is merged with the current
+     * environment's block. Files without a '*' key are flat and untouched.
+     *
+     * @param array<array-key, mixed> $config
+     * @return array<array-key, mixed>
+     */
+    public static function resolveEnvironmentConfig(array $config, string $environment): array {
+        if (!isset($config['*']) || !is_array($config['*'])) {
+            return $config;
+        }
+
+        $environmentConfig = $config[$environment] ?? [];
+
+        return array_merge($config['*'], is_array($environmentConfig) ? $environmentConfig : []);
+    }
+
+    private static function environment(): string {
+        return Craft::$app->env ?? getenv('CRAFT_ENVIRONMENT') ?: 'production';
+    }
+
+    /**
+     * Safe defaults per environment, applied before any config file.
      */
     private static function applyProductionDefaults(Settings $settings): Settings {
-        $environment = Craft::$app->env ?? getenv('CRAFT_ENVIRONMENT') ?: 'production';
-
-        if ($environment === 'production') {
+        if (self::environment() === 'production') {
             $settings->enabled = false;
             $settings->enableDangerousTools = false;
         }

--- a/src/prompts/EntryPrompts.php
+++ b/src/prompts/EntryPrompts.php
@@ -172,6 +172,43 @@ PROMPT);
     }
 
     /**
+     * Generate a prompt for reviewing the pending draft queue.
+     *
+     * @return array{array{role: string, content: string}}
+     */
+    #[McpPrompt(
+        name: 'review_pending_drafts',
+        description: 'Walk through the pending entry drafts awaiting review: inspect, publish, or reject each one.',
+    )]
+    #[McpPromptMeta(category: PromptCategory::WORKFLOW)]
+    public function reviewPendingDrafts(
+        #[CompletionProvider(provider: SectionHandleProvider::class)]
+        ?string $section = null,
+    ): array {
+        return SafePromptExecution::run(function () use ($section): array {
+            $query = Entry::find()->drafts()->provisionalDrafts(false)->status(null);
+            if ($section !== null) {
+                $query->section($section);
+            }
+
+            $pending = (int) $query->count();
+            $scopeLine = $section !== null ? "the \"{$section}\" section" : 'all sections';
+
+            return $this->promptResponse(<<<PROMPT
+I want to review the pending entry drafts in {$scopeLine}. There are currently {$pending} non-provisional drafts awaiting review.
+
+Please walk me through the review queue:
+1. Call list_drafts (filter by section, site, or creator as needed) to get the queue, newest first; each row has a draftElementId, the creator, the draft notes, and a cpEditUrl
+2. For each draft I pick: fetch its content with get_entry using the draftElementId, and summarize what it changes (for edits to existing entries, compare against get_entry on the canonicalId)
+3. To approve: publish_entry with the draftElementId; to reject: delete_entry with the draftElementId (the canonical entry is untouched either way)
+4. Share the cpEditUrl whenever I want to look at a draft in the control panel myself
+
+Start by showing me the queue.
+PROMPT);
+        });
+    }
+
+    /**
      * Filter entry types to a specific one if provided.
      *
      * @return list<EntryType>|null

--- a/src/resources/GuideResources.php
+++ b/src/resources/GuideResources.php
@@ -56,7 +56,7 @@ Call `describe_entry_schema` for the section and entry type before writing. Pass
 - `create_entry` saves a draft; `update_entry` on a live entry creates a draft on top, leaving the live version untouched.
 - Responses carry `draftElementId` and a `cpEditUrl` deep link for human review in the control panel.
 - `publish_entry` applies the draft (canonical id when one pending draft exists, the specific `draftElementId` when several).
-- `delete_entry` soft-deletes to the trash; `duplicate_entry` clones as a draft with overrides; `copy_entry_to_site` copies values to another site's version as a draft.
+- `list_drafts` lists the pending review queue (newest first, filterable by section, site, or creator); `delete_entry` soft-deletes to the trash; `duplicate_entry` clones as a draft with overrides; `copy_entry_to_site` copies values to another site's version as a draft.
 - Pass `mode: "live"` per call (or set the `entryWriteMode` setting) for immediate saves.
 
 ## Structured feedback

--- a/src/resources/GuideResources.php
+++ b/src/resources/GuideResources.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace stimmt\craft\Mcp\resources;
 
 use Mcp\Capability\Attribute\McpResource;
+use Mcp\Exception\ResourceReadException;
 use stimmt\craft\Mcp\attributes\McpResourceMeta;
 use stimmt\craft\Mcp\enums\ResourceCategory;
 
 /**
- * Static guides agents can pull on demand: the content-writing contract in
- * full, without bloating the per-connection server instructions.
+ * Guides agents can pull on demand, served straight from the shipped docs
+ * pages so there is exactly one copy of each contract to maintain.
  *
  * @author Max van Essen <support@stimmt.digital>
  */
@@ -21,53 +22,22 @@ final class GuideResources {
     #[McpResource(
         uri: 'craft://guides/content-writing',
         name: 'content-writing-guide',
-        description: 'The full content-writing contract for agents: payload format, natural keys, Matrix shape, draft-first workflow, schema discovery with input shapes, and structured feedback.',
+        description: 'The full content-writing contract for agents: payload format, natural keys, Matrix shape, draft-first workflow with the pending-drafts review queue, schema discovery with input shapes, and structured feedback.',
         mimeType: 'text/markdown',
     )]
     #[McpResourceMeta(category: ResourceCategory::CONTENT)]
     public function contentWriting(): string {
-        return <<<'GUIDE'
-# Content Writing Contract
+        return $this->doc('content-writing.md');
+    }
 
-Entry reads and writes share one format: what `get_entry` returns is exactly what `create_entry` and `update_entry` accept. Read an entry, tweak it, write it back.
+    private function doc(string $file): string {
+        $path = dirname(__DIR__, 2) . '/docs/' . $file;
+        $content = @file_get_contents($path);
 
-## Natural keys, no numeric IDs
+        if ($content === false) {
+            throw new ResourceReadException("Guide '{$file}' is missing from this installation");
+        }
 
-| Target | Key shape | Example |
-|--------|-----------|---------|
-| Entries | `{section, slug}` | `{"section": "pages", "slug": "about"}` |
-| Assets | `{volume, path?, filename}` | `{"volume": "images", "filename": "hero.jpg"}` |
-| Categories / Tags | `{group, slug}` | `{"group": "topics", "slug": "craft"}` |
-| Users | `{username}` | `{"username": "anna"}` |
-| Global sets | `{handle}` | `{"handle": "footer"}` |
-
-Relation fields take a list of these maps. Numeric IDs are also accepted, but reads always emit keys.
-
-## Matrix blocks
-
-Objects keyed by block id (`new1`, `new2`, ... for new blocks), each with the entry-type handle as `type`, optional `title` and `enabled`, and a `fields` map. Disabled blocks are preserved on round trips.
-
-## Discover the shape first
-
-Call `describe_entry_schema` for the section and entry type before writing. Pass `example` (an entry id or slug) to include a real entry as a golden fixture. Every field carries an `input` shape: the exact payload it accepts (natural-key format for relations, block types for Matrix, allowed values for options, columns for tables, link types for link fields, value types for scalars). When an `input` carries a `note` saying nested values pass through unchanged, send stored IDs or ref strings inside that field, not natural keys.
-
-## Draft-first writes
-
-- `create_entry` saves a draft; `update_entry` on a live entry creates a draft on top, leaving the live version untouched.
-- Responses carry `draftElementId` and a `cpEditUrl` deep link for human review in the control panel.
-- `publish_entry` applies the draft (canonical id when one pending draft exists, the specific `draftElementId` when several).
-- `list_drafts` lists the pending review queue (newest first, filterable by section, site, or creator); `delete_entry` soft-deletes to the trash; `duplicate_entry` clones as a draft with overrides; `copy_entry_to_site` copies values to another site's version as a draft.
-- Pass `mode: "live"` per call (or set the `entryWriteMode` setting) for immediate saves.
-
-## Structured feedback
-
-- Validation failures return per-field errors.
-- Unresolvable natural keys become warnings on an otherwise successful save; nothing is guessed, nothing is silently dropped.
-- Read the `warnings` list on every write response.
-
-## Multi-site
-
-Read and write tools accept a `site` handle parameter; natural keys resolve within that site.
-GUIDE;
+        return $content;
     }
 }

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace stimmt\craft\Mcp\tools;
 
 use Craft;
+use craft\behaviors\DraftBehavior;
 use craft\elements\Entry;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
@@ -21,7 +22,7 @@ use stimmt\craft\Mcp\support\SafeExecution;
 use stimmt\craft\Mcp\support\SiteResolver;
 
 /**
- * Entry workflow: publish, delete, duplicate, copy to site.
+ * Entry workflow: the pending-drafts review queue, publish, delete, duplicate, copy to site.
  *
  * @author Max van Essen <support@stimmt.digital>
  */
@@ -33,6 +34,48 @@ class EntryWorkflowTools {
     public function __construct(?Reader $reader = null, ?Writer $writer = null) {
         $this->reader = $reader ?? ElementModule::reader();
         $this->writer = $writer ?? ElementModule::writer();
+    }
+
+    #[McpTool(
+        name: 'list_drafts',
+        description: 'List pending (non-provisional) entry drafts awaiting review, newest first. Filter by section, site, or creator username/email. Each row carries the draft element id publish_entry accepts and a cpEditUrl for human review.',
+    )]
+    #[McpToolMeta(category: ToolCategory::CONTENT)]
+    public function listDrafts(
+        ?string $section = null,
+        ?string $site = null,
+        ?string $creator = null,
+        int $limit = 20,
+        int $offset = 0,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($section, $site, $creator, $limit, $offset): array {
+            SiteResolver::resolve($site);
+
+            $query = Entry::find()
+                ->drafts()
+                ->provisionalDrafts(false)
+                ->status(null)
+                ->limit($limit)
+                ->offset($offset)
+                ->orderBy(['dateUpdated' => SORT_DESC]);
+
+            foreach (['section' => $section, 'site' => $site] as $method => $value) {
+                if ($value !== null) {
+                    $query->$method($value);
+                }
+            }
+
+            if ($creator !== null) {
+                $user = Craft::$app->getUsers()->getUserByUsernameOrEmail($creator)
+                    ?? throw new ToolCallException("No user found for '{$creator}'");
+                $query->draftCreator($user);
+            }
+
+            $drafts = array_map($this->draftSummary(...), $query->all());
+
+            return Response::paginated('drafts', $drafts, (int) $query->count(), $limit, $offset);
+        });
     }
 
     #[McpTool(
@@ -129,6 +172,32 @@ class EntryWorkflowTools {
                 ? ['success' => false] + $result->toArray()
                 : Response::success($result->toArray());
         });
+    }
+
+    /**
+     * One review-queue row: identifiers for the tools, a deep link for the
+     * human, and the draft note for context.
+     *
+     * @return array<string, mixed>
+     */
+    private function draftSummary(Entry $draft): array {
+        $behavior = $draft->getBehavior('draft');
+        $creator = $behavior instanceof DraftBehavior ? $behavior->getCreator() : null;
+        $notes = $behavior instanceof DraftBehavior ? $behavior->draftNotes : null;
+
+        return [
+            'draftElementId' => (int) $draft->id,
+            'canonicalId' => (int) $draft->getCanonicalId(),
+            'isNewEntry' => $draft->getIsUnpublishedDraft(),
+            'title' => (string) $draft->title,
+            'section' => $draft->getSection()?->handle,
+            'type' => $draft->getType()->handle,
+            'site' => $draft->getSite()->handle,
+            'creator' => $creator?->username,
+            'notes' => $notes,
+            'dateUpdated' => $draft->dateUpdated?->format('Y-m-d H:i:s'),
+            'cpEditUrl' => $draft->getCpEditUrl(),
+        ];
     }
 
     private function applyDraft(Entry $draft, ?string $site): array {

--- a/tests/Unit/Models/EnvironmentConfigTest.php
+++ b/tests/Unit/Models/EnvironmentConfigTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 3) . '/vendor/yiisoft/yii2/Yii.php';
+
+use stimmt\craft\Mcp\Mcp;
+
+describe('Mcp::resolveEnvironmentConfig', function () {
+    it('leaves flat configs untouched', function () {
+        $config = ['enabled' => true, 'logLevel' => 'debug'];
+
+        expect(Mcp::resolveEnvironmentConfig($config, 'production'))->toBe($config);
+    });
+
+    it('merges the star base with the current environment block', function () {
+        $config = [
+            '*' => ['enabled' => true, 'logLevel' => 'error'],
+            'dev' => ['logLevel' => 'debug', 'enableDangerousTools' => true],
+            'production' => ['enableDangerousTools' => false],
+        ];
+
+        expect(Mcp::resolveEnvironmentConfig($config, 'dev'))
+            ->toBe(['enabled' => true, 'logLevel' => 'debug', 'enableDangerousTools' => true])
+            ->and(Mcp::resolveEnvironmentConfig($config, 'production'))
+            ->toBe(['enabled' => true, 'logLevel' => 'error', 'enableDangerousTools' => false]);
+    });
+
+    it('falls back to the star base alone for unknown environments', function () {
+        $config = ['*' => ['enabled' => true], 'dev' => ['logLevel' => 'debug']];
+
+        expect(Mcp::resolveEnvironmentConfig($config, 'staging'))->toBe(['enabled' => true]);
+    });
+});

--- a/tests/Unit/Resources/GuideResourcesTest.php
+++ b/tests/Unit/Resources/GuideResourcesTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\resources\GuideResources;
+
+describe('GuideResources', function () {
+    it('serves the shipped content-writing guide with the full contract', function () {
+        $guide = (new GuideResources())->contentWriting();
+
+        expect($guide)->toContain('{"section": "pages", "slug": "about"}')
+            ->and($guide)->toContain('describe_entry_schema')
+            ->and($guide)->toContain('publish_entry')
+            ->and($guide)->toContain('list_drafts')
+            ->and($guide)->toContain('warnings');
+    });
+});


### PR DESCRIPTION
## What

Closes the last gap in the draft-first editor loop: agents could create drafts all day but could not enumerate what awaits review.

- **`list_drafts` tool**: pending (non-provisional) entry drafts newest first, filterable by section, site, or creator (username/email). Each row carries `draftElementId` (what `publish_entry`/`get_entry` accept), `canonicalId` with an `isNewEntry` flag, title, section/type/site, creator, draft notes, and a `cpEditUrl` deep link. Not flagged dangerous, so `readonly` HTTP tokens can review the queue, since reviewing is reading.
- **`review_pending_drafts` prompt**: drives the loop conversationally with the live pending count embedded: list the queue, inspect a draft via `get_entry` (comparing against the canonical for edits), approve via `publish_entry`, reject via `delete_entry`, or hand the human the control panel link.
- Docs for both in the tools reference and prompts pages.

## Verify

- Live against the playground: `list_drafts` returned the real queue (63 pending drafts) with correct draft element ids, canonical ids, and deep links.
- Both integration drivers stay green (27/0 elements, 34/0 HTTP); full gate green (pest 281, PHPStan, Rector, Pint).

## Also in this PR (docs audit fallout)

A completeness audit of the docs against the code surfaced two behavior gaps and a batch of accuracy errors, all resolved here:

- **Security fix**: production safety defaults (`enabled`, `enableDangerousTools` off) now apply BEFORE `config/mcp.php` is read, instead of only when no config file exists. Previously, creating the config file (as every quick start instructs) silently re-enabled dangerous tools in production. Explicit keys in the file still win.
- **Multi-environment config**: `config/mcp.php` now supports the documented `'*'`-base convention (merged with the current environment's block), which the loader used to ignore. Unit-tested resolver.
- The `craft://guides/content-writing` resource is now served straight from the shipped docs page (one copy of the contract, guarded by a unit test).
- Fourteen doc corrections from the audit: real response shapes and parameter tables for the category/asset/user list tools, `list_volumes` re-filed under its actual code category with corrected counts, the complete 11-tool dangerous list, the real tinker blocklist plus its not-a-sandbox caveat, two previously undocumented settings (`disabledPrompts`, `disabledResources`), and consistency notes. Plus an em-dash sweep of the remaining tools pages.
