### PR TITLE
feat: content query surface (filters, count_entries, revisions, query_graphql)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `count_entries` tool: totals and per-value breakdowns (attribute, date bucket, or field-value grouping) with the same filters as `list_entries`
+- Field-value `filters`, `relatedTo`, `author`, and date-range parameters on `list_entries`, with natural keys and `:empty:`/`:notempty:` support
+- `fields` projection on `list_entries` for slim rows when scanning many entries
+- `list_revisions` tool: an entry's saved history (who, when, notes); `get_entry` now reads revision ids
+- `query_graphql` tool: read-only GraphQL queries (mutations rejected at parse time), not gated by `enableDangerousTools`
+- Read-only and idempotent annotations on every non-dangerous tool
+- Tool-selection ladder in the server instructions, prompt guides, and the `tinker`/`run_query` descriptions
+
 ## [1.4.0-beta.4] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fields` projection on `list_entries` for slim rows when scanning many entries
 - `list_revisions` tool: an entry's saved history (who, when, notes); `get_entry` now reads revision ids
 - `query_graphql` tool: read-only GraphQL queries (mutations rejected at parse time), not gated by `enableDangerousTools`
-- Read-only and idempotent annotations on every non-dangerous tool
+- Read-only and idempotent annotations on every non-dangerous tool (reload_mcp exempt)
 - Tool-selection ladder in the server instructions, prompt guides, and the `tinker`/`run_query` descriptions
 
 ## [1.4.0-beta.4] - 2026-07-10

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Entry reads and writes share one payload format: relations as natural keys (`{"s
 
 | Category | Highlights |
 |----------|-----------|
-| [Content](docs/tools/content.md) | Entries (payload-format read/write, draft workflow with a pending-drafts review queue, publish/duplicate/copy to site), schema discovery via `describe_entry_schema`, assets, categories, users, globals |
+| [Content](docs/tools/content.md) | Entries (payload-format read/write, field/relation/date filters, count and group-by breakdowns, draft workflow with a pending-drafts review queue and revision history, publish/duplicate/copy to site), schema discovery via `describe_entry_schema`, assets, categories, users, globals |
 | [System](docs/tools/system.md) | System info, config, logs, caches, routes, console commands |
 | [Database](docs/tools/database.md) | Schema inspection, table counts, read-only queries |
 | [Debugging](docs/tools/debugging.md) | Queue jobs, project config diff, deprecations, EXPLAIN, event handlers, and a Tinker tool for executing PHP in the Craft context |
 | [Multi-Site](docs/tools/multisite.md) | Sites, site groups, per-site details |
-| [GraphQL](docs/tools/graphql.md) | Schemas, SDL, query execution, tokens |
+| [GraphQL](docs/tools/graphql.md) | Schemas, SDL, read-only and mutating query execution, tokens |
 | [Backup](docs/tools/backup.md) | Create and list database backups |
 | [Self-Awareness](docs/tools/mcp.md) | Plugin info, tool listing with risk annotations, hot reload |
 | [Commerce](docs/tools/commerce.md) | Products, orders, and statuses (when Craft Commerce is installed) |

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "test:coverage": "pest --coverage --min=80",
         "test:type": "pest --type-coverage --min=90",
         "test:arch": "pest --filter=Arch",
-        "analyse": "phpstan analyse",
+        "analyse": "phpstan analyse --memory-limit=512M",
         "ci": [
             "@lint:test",
             "@analyse",

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Craft MCP provides 56 tools that give AI assistants comprehensive access to your Craft installation. This page provides a quick reference to all available tools, organized by category.
+Craft MCP provides 59 tools that give AI assistants comprehensive access to your Craft installation. This page provides a quick reference to all available tools, organized by category.
 
 ## Tool Categories
 
@@ -8,13 +8,13 @@ The tools are organized into logical categories based on what they do:
 
 | Category | Tools | Description |
 |----------|-------|-------------|
-| [Content](content.md) | 16 | Query and manage entries (payload-format read/write, draft workflow, publish/duplicate/copy to site), assets, categories, users, and global sets |
+| [Content](content.md) | 18 | Query and manage entries (payload-format read/write, filters, counts, revision history, draft workflow, publish/duplicate/copy to site), assets, categories, users, and global sets |
 | [System](system.md) | 7 | Access configuration, logs, caches, routes, and system information |
 | [Database](database.md) | 4 | Inspect database schema, run queries, and explore table structures |
 | [Debugging](debugging.md) | 7 | Monitor queue jobs, project config changes, deprecations, and more |
 | Schema | 4 | Inspect sections, fields, and plugins; discover an entry type's write schema |
 | [Multi-Site](multisite.md) | 3 | Manage and inspect multi-site configurations |
-| [GraphQL](graphql.md) | 4 | Query schemas, tokens, and execute GraphQL operations |
+| [GraphQL](graphql.md) | 5 | Query schemas, tokens, and execute read-only or mutating GraphQL operations |
 | [Backup](backup.md) | 2 | List and create database backups |
 | [Self-Awareness](mcp.md) | 3 | Inspect MCP plugin status, available tools, and hot-reload |
 | [Commerce](commerce.md) | 6 | Product and order management (requires Craft Commerce) |
@@ -29,11 +29,13 @@ These tools let AI assistants work with your Craft content:
 
 | Tool | Description |
 |------|-------------|
-| `list_entries` | List entries, filtering by section, type, status, site, and full-text search; returns the payload format |
+| `list_entries` | List entries, filtering by section, type, status, site, full-text search, field values, relations, author, and date ranges; returns the payload format, optionally projected via `fields` |
+| `count_entries` | Count entries with the same filters as `list_entries`; optional `groupBy` for per-attribute, per-date-bucket, or per-field-value breakdowns |
 | `get_entry` | Get one entry by id or slug, in the payload format that `create_entry`/`update_entry` accept as `fields` |
 | `create_entry` | Create an entry from payload-format `fields`; saves as a draft by default |
 | `update_entry` | Update an entry by id from payload-format `fields`; drafts on top of a live entry by default |
 | `list_drafts` | List pending drafts awaiting review, newest first, with publish ids and control panel links |
+| `list_revisions` | List an entry's saved revisions, newest first: who saved each one, when, and with what notes |
 | `publish_entry` | Apply a pending draft to its canonical entry, or enable a disabled live entry |
 | `delete_entry` | Soft-delete an entry to the trash, restorable from the control panel |
 | `duplicate_entry` | Duplicate an entry as an unpublished draft, with optional field overrides |
@@ -116,6 +118,7 @@ These tools provide access to Craft's GraphQL API:
 |------|-------------|
 | `list_graphql_schemas` | List all GraphQL schemas with their scopes and permissions |
 | `get_graphql_schema` | Get schema details including the SDL (Schema Definition Language) |
+| `query_graphql` | Run a read-only GraphQL query; mutations and subscriptions are rejected before execution |
 | `execute_graphql` | Execute GraphQL queries and mutations against your Craft installation |
 | `list_graphql_tokens` | List API tokens with their associated schemas |
 

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -104,7 +104,7 @@ When `fields` (the projection parameter) is given, each row is slimmed down to `
 
 ### count_entries
 
-Count entries, optionally grouped: by attribute (`status`, `type`, `section`, `site`, `author`), by date bucket (`"month:dateUpdated"`, any of `day`/`week`/`month`/`year` with `dateCreated`/`dateUpdated`/`postDate`), or by a field handle (relation fields bucket by related title; empty values fall under `"(empty)"`). Takes the same filters as `list_entries`. One call answers "how many per X" without listing anything.
+Count entries, optionally grouped: by attribute (`status`, `type`, `section`, `site`, `author`), by date bucket (`"month:dateUpdated"`, any of `day`/`week`/`month`/`year` with `dateCreated`/`dateUpdated`/`postDate`), or by a field handle (relation fields bucket by related title; empty values fall under `"(empty)"`). Takes the same filters as `list_entries`. Counts include every status by default, while list_entries defaults to live entries only; pass status to narrow either. One call answers "how many per X" without listing anything.
 
 **Parameters:**
 

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -8,7 +8,7 @@ Entries are the primary content type in Craft CMS. Reads and writes share one pa
 
 ### list_entries
 
-List entries. Filter by section, type, status, site handle, and full-text search. Returns entries in the payload format described above.
+List entries. Filter by section, type, status, site handle, full-text search, field values (with `:empty:`/`:notempty:` and natural keys for relations), `relatedTo`, author, and date ranges. Returns entries in the payload format described above.
 
 **Parameters:**
 
@@ -19,6 +19,14 @@ List entries. Filter by section, type, status, site handle, and full-text search
 | `status` | string | null | Filter by status: "live", "pending", "expired", "disabled", or "any" |
 | `site` | string | null | Site handle to query and read fields from (defaults to the primary site) |
 | `search` | string | null | Full-text search term |
+| `filters` | object | null | Field-value filters: `{fieldHandle: value}`. Values are scalars, `":empty:"`, `":notempty:"`, or a natural key object for relation fields (e.g. `{"group": "...", "slug": "..."}`) |
+| `relatedTo` | object | null | Only entries related to this element, as a natural key: `{"section", "slug"}`, `{"volume", "filename"}`, `{"group", "slug"}`, or `{"username"}` |
+| `author` | string | null | Filter by the author's username or email |
+| `updatedAfter` | string | null | ISO date/datetime; only entries updated on or after this |
+| `updatedBefore` | string | null | ISO date/datetime; only entries updated before this |
+| `createdAfter` | string | null | ISO date/datetime; only entries created on or after this |
+| `createdBefore` | string | null | ISO date/datetime; only entries created before this |
+| `fields` | array of string | null | Projection: return only these attributes and field handles per entry (`id` and `title` always included) instead of the full payload. Ideal for scanning many entries |
 | `limit` | int | 20 | Maximum number of entries to return |
 | `offset` | int | 0 | Number of entries to skip (for pagination) |
 
@@ -36,6 +44,18 @@ list_entries section="news" search="product launch"
 
 # Paginate through results
 list_entries section="products" limit=20 offset=40
+
+# Field filters: a scalar, ":empty:", and a natural key, combined
+list_entries section="news" filters={"featured": true, "summary": ":empty:", "category": {"group": "topics", "slug": "company"}}
+
+# Only entries related to a specific asset
+list_entries relatedTo={"volume": "images", "filename": "hero.jpg"}
+
+# Entries by a specific author, updated since the start of the year
+list_entries author="anna@site.nl" updatedAfter="2024-01-01"
+
+# Slim rows for scanning many entries: id, title, plus these attributes/fields only
+list_entries section="news" fields=["slug", "status", "dateUpdated"] limit=200
 ```
 
 **Response:**
@@ -78,6 +98,87 @@ list_entries section="products" limit=20 offset=40
 
 `status` is the element's publish status (`live`, `pending`, `expired`, `disabled`); `state` is `draft` or `live`, i.e. whether this record is a draft awaiting `publish_entry` or the canonical version. `fields` holds custom field values in the payload format: relation fields as lists of natural keys, Matrix fields as block objects keyed by id. `warnings` lists any natural key in this entry's fields that failed to resolve to an element; see [Content Writing: Structured Feedback](../content-writing.md#structured-feedback).
 
+When `fields` (the projection parameter) is given, each row is slimmed down to `id`, `title`, the requested attributes, and a `fields` object holding only the requested field handles, instead of the full payload above.
+
+---
+
+### count_entries
+
+Count entries, optionally grouped: by attribute (`status`, `type`, `section`, `site`, `author`), by date bucket (`"month:dateUpdated"`, any of `day`/`week`/`month`/`year` with `dateCreated`/`dateUpdated`/`postDate`), or by a field handle (relation fields bucket by related title; empty values fall under `"(empty)"`). Takes the same filters as `list_entries`. One call answers "how many per X" without listing anything.
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `section` | string | null | Filter by section handle |
+| `type` | string | null | Filter by entry type handle |
+| `status` | string | null | Filter by status: "live", "pending", "expired", "disabled", or "any" |
+| `site` | string | null | Site handle to query (defaults to the primary site) |
+| `search` | string | null | Full-text search term |
+| `filters` | object | null | Field-value filters: `{fieldHandle: value}`. Values are scalars, `":empty:"`, `":notempty:"`, or a natural key object for relation fields |
+| `relatedTo` | object | null | Only entries related to this element, as a natural key |
+| `author` | string | null | Filter by the author's username or email |
+| `updatedAfter` | string | null | ISO date/datetime; only entries updated on or after this |
+| `updatedBefore` | string | null | ISO date/datetime; only entries updated before this |
+| `createdAfter` | string | null | ISO date/datetime; only entries created on or after this |
+| `createdBefore` | string | null | ISO date/datetime; only entries created before this |
+| `groupBy` | string | null | An attribute (`status`, `type`, `section`, `site`, `author`), a date bucket (`granularity:dateAttribute`, e.g. `"month:dateUpdated"`), or a field handle. Omit for a plain total |
+
+**Examples:**
+
+```
+# Plain total
+count_entries section="news"
+
+# Per-status breakdown
+count_entries section="news" groupBy="status"
+
+# Entries per month, by last update
+count_entries section="news" groupBy="month:dateUpdated"
+
+# Per-value breakdown on a relation field
+count_entries section="news" groupBy="category"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "total": 245,
+  "groupBy": null
+}
+```
+
+With `groupBy`, a `buckets` list is added, one entry per distinct value, sorted by count descending (chronologically for date buckets):
+
+```json
+{
+  "success": true,
+  "total": 245,
+  "buckets": [
+    { "key": "2023-12", "count": 18 },
+    { "key": "2024-01", "count": 32 }
+  ],
+  "groupBy": "month:dateUpdated"
+}
+```
+
+```json
+{
+  "success": true,
+  "total": 5000,
+  "buckets": [
+    { "key": "Technology", "count": 120 },
+    { "key": "(empty)", "count": 40 }
+  ],
+  "truncated": true,
+  "groupBy": "category"
+}
+```
+
+`buckets` is capped at 200 entries; when a grouping produces more distinct values than that, only the top 200 are returned and `truncated` is `true`.
+
 ---
 
 ### get_entry
@@ -119,7 +220,7 @@ Returns a single entry object with the same structure as `list_entries` (see abo
 }
 ```
 
-An `id` lookup also matches drafts, so an agent can read back the draft a previous write just created.
+An `id` lookup also matches drafts and revisions, so an agent can read back the draft a previous write just created, or inspect a past revision's content using the `revisionElementId` from `list_revisions`.
 
 ---
 
@@ -352,6 +453,62 @@ list_drafts section="pages" creator="anna@site.nl"
 ```
 
 The `review_pending_drafts` prompt walks through this queue conversationally: inspect, publish, or reject each draft.
+
+---
+
+### list_revisions
+
+List an entry's saved revisions, newest first: who saved each one, when, and with what notes. Answers "when did this change and by whom". Read a revision's full content with `get_entry` using its `revisionElementId`; the canonical entry id always holds the current content.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | int | Yes | Canonical entry id whose revisions to list |
+| `site` | string | No | Site handle (defaults to the primary site) |
+| `limit` | int | No | Maximum revisions to return (default: 20) |
+| `offset` | int | No | Offset for pagination (default: 0) |
+
+**Example:**
+
+```
+list_revisions id=123
+```
+
+**Response:**
+
+```json
+{
+  "count": 2,
+  "total": 2,
+  "limit": 20,
+  "offset": 0,
+  "revisions": [
+    {
+      "revisionElementId": 512,
+      "canonicalId": 123,
+      "revisionNum": 4,
+      "title": "About Us",
+      "creator": "anna",
+      "notes": "Updated hero copy",
+      "dateCreated": "2024-01-15 14:22:00"
+    },
+    {
+      "revisionElementId": 498,
+      "canonicalId": 123,
+      "revisionNum": 3,
+      "title": "About Us",
+      "creator": "anna",
+      "notes": null,
+      "dateCreated": "2024-01-10 09:15:00"
+    }
+  ]
+}
+```
+
+`revisionElementId` is what `get_entry` accepts to read that revision's full content. `canonicalId` is the live entry the revision belongs to. `revisionNum` is Craft's sequential revision number for the entry. `creator` and `notes` come from whoever saved the revision and any note left at the time; either can be `null`.
+
+---
 
 ### publish_entry
 

--- a/docs/tools/database.md
+++ b/docs/tools/database.md
@@ -154,7 +154,7 @@ Sometimes you need to query the database directly. The `run_query` tool provides
 
 ### run_query
 
-Execute read-only SQL queries against your database. This is classified as a dangerous tool because it can expose data, but it's restricted to SELECT statements only.
+Execute read-only SQL queries against your database. Best suited for custom plugin tables and aggregate SQL that no structured tool covers; for table and column discovery use `get_database_schema` instead of hand-written `information_schema` queries, and for entry content prefer `list_entries`/`count_entries` over querying the content tables directly. This is classified as a dangerous tool because it can expose data, but it's restricted to SELECT statements only.
 
 > **Note:** This tool can be disabled via configuration. See the [Configuration Guide](../configuration.md).
 

--- a/docs/tools/debugging.md
+++ b/docs/tools/debugging.md
@@ -351,7 +351,7 @@ Sometimes you need to run arbitrary PHP code to debug an issue or inspect applic
 
 ### tinker
 
-Execute PHP code within your Craft application context. This is a powerful tool for debugging, inspection, and quick one-off operations. It's classified as dangerous and can be disabled via configuration.
+Execute PHP code within your Craft application context. Prefer a specific tool when one exists (content, schema, database tools); reach for `tinker` when none can express the job, such as cross-entry computation. This is a powerful tool for debugging, inspection, and quick one-off operations. It's classified as dangerous and can be disabled via configuration.
 
 > **Note:** This tool can be disabled via configuration. See the [Configuration Guide](../configuration.md).
 

--- a/docs/tools/graphql.md
+++ b/docs/tools/graphql.md
@@ -153,12 +153,11 @@ Same shape as `execute_graphql` below: `{"success": true, "data": {...}, "errors
 query_graphql query="mutation { save_news_default_Entry(title: \"x\") { id } }"
 ```
 
-```json
-{
-  "success": false,
-  "error": "Only query operations are allowed here; 'mutation' requires execute_graphql (dangerous tools)"
-}
+```text
+Error: Only query operations are allowed here; 'mutation' requires execute_graphql (dangerous tools)
 ```
+
+The rejection surfaces as an MCP error result (`isError: true`) carrying that message as text, not as a JSON body.
 
 Every operation in the query is parsed into a GraphQL AST and checked before Craft executes anything: any operation whose type is not `query` (a `mutation` or `subscription`) fails the call outright, before it ever reaches Craft's GraphQL executor. Because the check happens at parse time rather than through the permissions layer, `query_graphql` has no code path to a data-modifying mutation, so it stays available regardless of the `enableDangerousTools` setting, unlike `execute_graphql`.
 

--- a/docs/tools/graphql.md
+++ b/docs/tools/graphql.md
@@ -117,9 +117,56 @@ The `sdl` field contains the complete schema definition, this can be quite large
 
 ## Query Execution
 
+### query_graphql
+
+Run a read-only GraphQL query against Craft's GraphQL API. Mutations and subscriptions are rejected before execution, so this tool is safe for browsing any GraphQL-exposed data (assets, categories, users, plugin types) with exactly the response shape you ask for. Use `get_graphql_schema` to discover the available types first.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | string | Yes | The GraphQL query to execute |
+| `variables` | string | No | JSON string containing query variables |
+| `operationName` | string | No | Name of the operation (when the query contains multiple) |
+| `schemaId` | int | No | Schema ID to use (defaults to the public schema) |
+
+**Examples:**
+
+```
+# Simple query
+query_graphql query="{ entries(section: \"news\", limit: 5) { title, slug } }"
+
+# Query with variables
+query_graphql query="query GetEntry($id: [QueryArgument]) { entry(id: $id) { title } }" variables='{"id": 123}'
+
+# Using a specific schema
+query_graphql query="{ entries { title } }" schemaId=2
+```
+
+**Response:**
+
+Same shape as `execute_graphql` below: `{"success": true, "data": {...}, "errors": null}`.
+
+**Rejected mutation:**
+
+```
+query_graphql query="mutation { save_news_default_Entry(title: \"x\") { id } }"
+```
+
+```json
+{
+  "success": false,
+  "error": "Only query operations are allowed here; 'mutation' requires execute_graphql (dangerous tools)"
+}
+```
+
+Every operation in the query is parsed into a GraphQL AST and checked before Craft executes anything: any operation whose type is not `query` (a `mutation` or `subscription`) fails the call outright, before it ever reaches Craft's GraphQL executor. Because the check happens at parse time rather than through the permissions layer, `query_graphql` has no code path to a data-modifying mutation, so it stays available regardless of the `enableDangerousTools` setting, unlike `execute_graphql`.
+
+---
+
 ### execute_graphql
 
-Execute a GraphQL query or mutation against your Craft installation. This tool lets AI assistants fetch data using the same API your front-end applications use.
+Execute a GraphQL query or mutation against your Craft installation. This tool lets AI assistants fetch data using the same API your front-end applications use. For read-only work, prefer `query_graphql`: it is always available, since mutations cannot reach it.
 
 > **Note:** This is a dangerous tool that can modify data via mutations. It can be disabled via configuration.
 

--- a/src/elements/Attributes.php
+++ b/src/elements/Attributes.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\elements;
+
+use craft\base\ElementInterface;
+use craft\elements\Entry;
+use DateTimeInterface;
+use InvalidArgumentException;
+
+/**
+ * Single source for the payload attribute formulas shared by the full Reader
+ * payload and the slim Projection rows, so formats never drift between them.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class Attributes {
+    public static function value(ElementInterface $element, string $attribute): mixed {
+        return match ($attribute) {
+            'id' => $element->id,
+            'canonicalId' => $element->getCanonicalId(),
+            'title' => $element->title,
+            'slug' => $element->slug,
+            'status' => $element->getStatus(),
+            'state' => $element->getIsDraft() ? WriteMode::Draft->value : WriteMode::Live->value,
+            'draftId' => $element->draftId ?? null,
+            'siteId' => $element->siteId,
+            'siteHandle' => $element->getSite()->handle,
+            'dateCreated' => self::date($element->dateCreated),
+            'dateUpdated' => self::date($element->dateUpdated),
+            'url' => $element->getUrl(),
+            'cpEditUrl' => $element->getCpEditUrl(),
+            'sectionHandle' => $element instanceof Entry ? $element->getSection()?->handle : null,
+            'typeHandle' => $element instanceof Entry ? $element->getType()->handle : null,
+            'authorId' => $element instanceof Entry ? $element->getAuthorId() : null,
+            'postDate' => $element instanceof Entry ? self::date($element->postDate) : null,
+            'expiryDate' => $element instanceof Entry ? self::date($element->expiryDate) : null,
+            default => throw new InvalidArgumentException("Unknown attribute '{$attribute}'"),
+        };
+    }
+
+    private static function date(?DateTimeInterface $date): ?string {
+        return $date?->format('Y-m-d H:i:s');
+    }
+}

--- a/src/elements/Reader.php
+++ b/src/elements/Reader.php
@@ -42,6 +42,19 @@ final readonly class Reader {
         return $this->translator->toKeys($fields, $values, $context);
     }
 
+    /**
+     * Payload-format values for a subset of an element's fields, for slim
+     * projections. Unknown handles are the caller's problem: filter first.
+     *
+     * @param string[] $handles
+     */
+    public function readFields(ElementInterface $element, array $handles, ?string $site = null): array {
+        $context = new Context($site ?? $element->getSite()->handle);
+        $fields = array_intersect_key(LayoutFields::of($element->getFieldLayout()), array_flip($handles));
+
+        return $this->translateFields($fields, $this->serializedFields($element, $fields), $context);
+    }
+
     private function attributes(ElementInterface $element): array {
         $attributes = [
             'id' => $element->id,

--- a/src/elements/Reader.php
+++ b/src/elements/Reader.php
@@ -19,6 +19,13 @@ use stimmt\craft\Mcp\elements\refs\Translator;
  * @author Max van Essen <support@stimmt.digital>
  */
 final readonly class Reader {
+    private const array COMMON_ATTRIBUTES = [
+        'id', 'canonicalId', 'title', 'slug', 'status', 'state', 'draftId',
+        'siteId', 'siteHandle', 'dateCreated', 'dateUpdated', 'url', 'cpEditUrl',
+    ];
+
+    private const array ENTRY_ATTRIBUTES = ['sectionHandle', 'typeHandle', 'authorId', 'postDate', 'expiryDate'];
+
     public function __construct(
         private Translator $translator,
     ) {
@@ -56,28 +63,13 @@ final readonly class Reader {
     }
 
     private function attributes(ElementInterface $element): array {
-        $attributes = [
-            'id' => $element->id,
-            'canonicalId' => $element->getCanonicalId(),
-            'title' => $element->title,
-            'slug' => $element->slug,
-            'status' => $element->getStatus(),
-            'state' => $element->getIsDraft() ? WriteMode::Draft->value : WriteMode::Live->value,
-            'draftId' => $element->draftId ?? null,
-            'siteId' => $element->siteId,
-            'siteHandle' => $element->getSite()->handle,
-            'dateCreated' => $element->dateCreated?->format('Y-m-d H:i:s'),
-            'dateUpdated' => $element->dateUpdated?->format('Y-m-d H:i:s'),
-            'url' => $element->getUrl(),
-            'cpEditUrl' => $element->getCpEditUrl(),
-        ];
+        $names = $element instanceof Entry
+            ? [...self::COMMON_ATTRIBUTES, ...self::ENTRY_ATTRIBUTES]
+            : self::COMMON_ATTRIBUTES;
 
-        if ($element instanceof Entry) {
-            $attributes['sectionHandle'] = $element->getSection()?->handle;
-            $attributes['typeHandle'] = $element->getType()->handle;
-            $attributes['authorId'] = $element->getAuthorId();
-            $attributes['postDate'] = $element->postDate?->format('Y-m-d H:i:s');
-            $attributes['expiryDate'] = $element->expiryDate?->format('Y-m-d H:i:s');
+        $attributes = [];
+        foreach ($names as $name) {
+            $attributes[$name] = Attributes::value($element, $name);
         }
 
         return $attributes;

--- a/src/elements/query/Buckets.php
+++ b/src/elements/query/Buckets.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace stimmt\craft\Mcp\elements\query;
 
 use Craft;
+use craft\base\EagerLoadingFieldInterface;
 use craft\base\ElementInterface;
 use craft\elements\db\ElementQueryInterface;
 use craft\elements\db\EntryQuery;
@@ -125,7 +126,7 @@ final class Buckets {
             'attribute' => [$this->attributeKey($entry, $parsed['target'])],
             'date' => [self::dateKey($entry->{$parsed['target']}, (string) $parsed['granularity'])],
             'field' => $this->fieldKeys($entry, $parsed['target']),
-            default => [self::EMPTY_KEY],
+            default => throw new InvalidArgumentException("Unknown groupBy kind '{$parsed['kind']}'"),
         };
     }
 
@@ -136,7 +137,7 @@ final class Buckets {
             'section' => $entry->getSection()?->handle,
             'site' => $entry->getSite()->handle,
             'author' => $entry->getAuthor()?->username,
-            default => null,
+            default => throw new InvalidArgumentException("Unknown attribute target '{$target}'"),
         };
 
         return $value !== null && $value !== '' ? $value : self::EMPTY_KEY;
@@ -207,11 +208,14 @@ final class Buckets {
     }
 
     private function assertFieldExists(string $handle, EntryQuery $query): void {
-        if (Craft::$app->getFields()->getFieldByHandle($handle) === null) {
-            throw new InvalidArgumentException("Unknown groupBy '{$handle}': not an attribute, date bucket, or field handle");
-        }
+        $field = Craft::$app->getFields()->getFieldByHandle($handle)
+            ?? throw new InvalidArgumentException("Unknown groupBy '{$handle}': not an attribute, date bucket, or field handle");
 
-        // Eager-load relations so field-value bucketing does not query per entry.
-        $query->with([$handle]);
+        // Eager-load relation values across ALL statuses so bucketing does
+        // not query per entry and non-live related elements keep their
+        // titles instead of collapsing into the (empty) bucket.
+        if ($field instanceof EagerLoadingFieldInterface) {
+            $query->with([[$handle, ['status' => null]]]);
+        }
     }
 }

--- a/src/elements/query/Buckets.php
+++ b/src/elements/query/Buckets.php
@@ -83,14 +83,37 @@ final class Buckets {
 
         $counts = [];
         foreach ($query->batch(100) as $batch) {
-            foreach ($batch as $entry) {
-                foreach ($this->keysFor($entry, $parsed) as $key) {
-                    $counts[$key] = ($counts[$key] ?? 0) + 1;
-                }
-            }
+            $counts = $this->tally($counts, $batch, $parsed);
         }
 
         return ['total' => $total] + $this->format($counts, $parsed['kind']);
+    }
+
+    /**
+     * @param array<string, int> $counts
+     * @param Entry[] $batch
+     * @param array{kind: string, target: string, granularity: ?string} $parsed
+     * @return array<string, int>
+     */
+    private function tally(array $counts, array $batch, array $parsed): array {
+        foreach ($batch as $entry) {
+            $counts = $this->increment($counts, $this->keysFor($entry, $parsed));
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @param array<string, int> $counts
+     * @param list<string> $keys
+     * @return array<string, int>
+     */
+    private function increment(array $counts, array $keys): array {
+        foreach ($keys as $key) {
+            $counts[$key] = ($counts[$key] ?? 0) + 1;
+        }
+
+        return $counts;
     }
 
     /**
@@ -137,7 +160,7 @@ final class Buckets {
             return $titles === [] ? [self::EMPTY_KEY] : $titles;
         }
 
-        if (is_iterable($value) && !is_string($value)) {
+        if (is_iterable($value)) {
             $keys = [];
             foreach ($value as $item) {
                 $keys[] = $this->scalarKey($item);

--- a/src/elements/query/Buckets.php
+++ b/src/elements/query/Buckets.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\elements\query;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\elements\db\ElementQueryInterface;
+use craft\elements\db\EntryQuery;
+use craft\elements\Entry;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Stringable;
+
+/**
+ * groupBy counting for count_entries: attribute buckets, date buckets
+ * (granularity:dateAttribute), or field-value buckets. Iterates the query in
+ * batches server-side so the client only ever sees the counts.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class Buckets {
+    private const array ATTRIBUTES = ['status', 'type', 'section', 'site', 'author'];
+
+    private const array DATE_ATTRIBUTES = ['dateCreated', 'dateUpdated', 'postDate'];
+
+    private const array GRANULARITIES = ['day', 'week', 'month', 'year'];
+
+    private const int MAX_BUCKETS = 200;
+
+    private const string EMPTY_KEY = '(empty)';
+
+    /**
+     * @return array{kind: string, target: string, granularity: ?string}
+     */
+    public static function parseGroupBy(string $groupBy): array {
+        if (in_array($groupBy, self::ATTRIBUTES, true)) {
+            return ['kind' => 'attribute', 'target' => $groupBy, 'granularity' => null];
+        }
+
+        if (str_contains($groupBy, ':')) {
+            [$granularity, $target] = explode(':', $groupBy, 2);
+            if (!in_array($granularity, self::GRANULARITIES, true) || !in_array($target, self::DATE_ATTRIBUTES, true)) {
+                throw new InvalidArgumentException(
+                    "Invalid date groupBy '{$groupBy}'; use day|week|month|year : dateCreated|dateUpdated|postDate",
+                );
+            }
+
+            return ['kind' => 'date', 'target' => $target, 'granularity' => $granularity];
+        }
+
+        return ['kind' => 'field', 'target' => $groupBy, 'granularity' => null];
+    }
+
+    public static function dateKey(?DateTimeInterface $date, string $granularity): string {
+        if ($date === null) {
+            return self::EMPTY_KEY;
+        }
+
+        return match ($granularity) {
+            'day' => $date->format('Y-m-d'),
+            'week' => $date->format('o-\WW'),
+            'month' => $date->format('Y-m'),
+            'year' => $date->format('Y'),
+            default => throw new InvalidArgumentException("Unknown granularity '{$granularity}'"),
+        };
+    }
+
+    /**
+     * @return array{total: int, buckets?: list<array{key: string, count: int}>, truncated?: bool}
+     */
+    public function collect(EntryQuery $query, ?string $groupBy): array {
+        $total = (int) $query->count();
+        if ($groupBy === null) {
+            return ['total' => $total];
+        }
+
+        $parsed = self::parseGroupBy($groupBy);
+        if ($parsed['kind'] === 'field') {
+            $this->assertFieldExists($parsed['target'], $query);
+        }
+
+        $counts = [];
+        foreach ($query->batch(100) as $batch) {
+            foreach ($batch as $entry) {
+                foreach ($this->keysFor($entry, $parsed) as $key) {
+                    $counts[$key] = ($counts[$key] ?? 0) + 1;
+                }
+            }
+        }
+
+        return ['total' => $total] + $this->format($counts, $parsed['kind']);
+    }
+
+    /**
+     * @param array{kind: string, target: string, granularity: ?string} $parsed
+     * @return list<string>
+     */
+    private function keysFor(Entry $entry, array $parsed): array {
+        return match ($parsed['kind']) {
+            'attribute' => [$this->attributeKey($entry, $parsed['target'])],
+            'date' => [self::dateKey($entry->{$parsed['target']}, (string) $parsed['granularity'])],
+            'field' => $this->fieldKeys($entry, $parsed['target']),
+            default => [self::EMPTY_KEY],
+        };
+    }
+
+    private function attributeKey(Entry $entry, string $target): string {
+        $value = match ($target) {
+            'status' => $entry->getStatus(),
+            'type' => $entry->getType()->handle,
+            'section' => $entry->getSection()?->handle,
+            'site' => $entry->getSite()->handle,
+            'author' => $entry->getAuthor()?->username,
+            default => null,
+        };
+
+        return $value !== null && $value !== '' ? $value : self::EMPTY_KEY;
+    }
+
+    /**
+     * Relation values bucket by related title; multi-value fields count once
+     * per value; everything empty lands in the shared (empty) bucket.
+     *
+     * @return list<string>
+     */
+    private function fieldKeys(Entry $entry, string $handle): array {
+        $value = $entry->getFieldValue($handle);
+
+        if ($value instanceof ElementQueryInterface) {
+            $titles = array_map(
+                static fn (ElementInterface $related): string => (string) ($related->title ?? $related->id),
+                $value->status(null)->all(),
+            );
+
+            return $titles === [] ? [self::EMPTY_KEY] : $titles;
+        }
+
+        if (is_iterable($value) && !is_string($value)) {
+            $keys = [];
+            foreach ($value as $item) {
+                $keys[] = $this->scalarKey($item);
+            }
+
+            return $keys === [] ? [self::EMPTY_KEY] : $keys;
+        }
+
+        return [$this->scalarKey($value)];
+    }
+
+    private function scalarKey(mixed $value): string {
+        if (in_array($value, [null, '', []], true)) {
+            return self::EMPTY_KEY;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d');
+        }
+
+        if (is_scalar($value) || $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return self::EMPTY_KEY;
+    }
+
+    /**
+     * @param array<string, int> $counts
+     * @return array{buckets: list<array{key: string, count: int}>, truncated?: bool}
+     */
+    private function format(array $counts, string $kind): array {
+        $kind === 'date' ? ksort($counts) : arsort($counts);
+
+        $truncated = count($counts) > self::MAX_BUCKETS;
+        $counts = array_slice($counts, 0, self::MAX_BUCKETS, true);
+
+        $buckets = [];
+        foreach ($counts as $key => $count) {
+            $buckets[] = ['key' => (string) $key, 'count' => $count];
+        }
+
+        return ['buckets' => $buckets] + ($truncated ? ['truncated' => true] : []);
+    }
+
+    private function assertFieldExists(string $handle, EntryQuery $query): void {
+        if (Craft::$app->getFields()->getFieldByHandle($handle) === null) {
+            throw new InvalidArgumentException("Unknown groupBy '{$handle}': not an attribute, date bucket, or field handle");
+        }
+
+        // Eager-load relations so field-value bucketing does not query per entry.
+        $query->with([$handle]);
+    }
+}

--- a/src/elements/query/Filters.php
+++ b/src/elements/query/Filters.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\elements\query;
+
+use Craft;
+use craft\elements\Asset;
+use craft\elements\Category;
+use craft\elements\db\EntryQuery;
+use craft\elements\Entry;
+use craft\elements\Tag;
+use craft\elements\User;
+use craft\fields\BaseRelationField;
+use InvalidArgumentException;
+use stimmt\craft\Mcp\elements\refs\Keys;
+
+/**
+ * Shared entry-query filters for the read tools (list_entries, count_entries).
+ * Translates the agent-facing filter params (field values with :empty: tokens,
+ * natural keys, ISO dates, usernames) onto a Craft entry query. Unresolvable
+ * input throws instead of silently matching everything.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final readonly class Filters {
+    /**
+     * relatedTo shape detection tries these in order; category before tag
+     * because their key shapes are identical and categories are the common
+     * relation target.
+     */
+    private const array RELATABLE_TYPES = [
+        Entry::class,
+        Asset::class,
+        Category::class,
+        Tag::class,
+        User::class,
+    ];
+
+    public function __construct(
+        private Keys $keys = new Keys(),
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>|null  $filters   field-value filters: {handle: value}
+     * @param array<string, string>|null $relatedTo natural key of the relation target
+     */
+    public function apply(
+        EntryQuery $query,
+        ?array $filters = null,
+        ?array $relatedTo = null,
+        ?string $author = null,
+        ?string $updatedAfter = null,
+        ?string $updatedBefore = null,
+        ?string $createdAfter = null,
+        ?string $createdBefore = null,
+        ?string $site = null,
+    ): void {
+        foreach ($filters ?? [] as $handle => $value) {
+            $query->{$handle}($this->fieldValue((string) $handle, $value, $site));
+        }
+
+        if ($relatedTo !== null) {
+            $query->relatedTo($this->resolveRelatedTo($relatedTo, $site));
+        }
+
+        if ($author !== null) {
+            $user = Craft::$app->getUsers()->getUserByUsernameOrEmail($author)
+                ?? throw new InvalidArgumentException("No user found for '{$author}'");
+            $query->authorId($user->id);
+        }
+
+        foreach ([
+            'dateUpdated' => self::dateParam($updatedAfter, $updatedBefore),
+            'dateCreated' => self::dateParam($createdAfter, $createdBefore),
+        ] as $attribute => $param) {
+            if ($param !== null) {
+                $query->{$attribute}($param);
+            }
+        }
+    }
+
+    /**
+     * Craft date-range param: ['and', '>= after', '< before'], or null when
+     * unbounded. Accepts anything Craft's DateTimeHelper parses (ISO dates).
+     *
+     * @return list<string>|null
+     */
+    public static function dateParam(?string $after, ?string $before): ?array {
+        if ($after === null && $before === null) {
+            return null;
+        }
+
+        return array_values(array_filter([
+            'and',
+            $after !== null ? ">= {$after}" : null,
+            $before !== null ? "< {$before}" : null,
+        ]));
+    }
+
+    /**
+     * A field filter value: scalars and :empty:/:notempty: pass through to
+     * Craft's field query params; arrays are natural keys, resolved to the
+     * related element id (relation fields only). Craft reserves query-param
+     * names, so a validated field handle never collides with a query method.
+     */
+    private function fieldValue(string $handle, mixed $value, ?string $site): mixed {
+        $field = Craft::$app->getFields()->getFieldByHandle($handle)
+            ?? throw new InvalidArgumentException("Unknown field handle '{$handle}' in filters");
+
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if (!$field instanceof BaseRelationField) {
+            throw new InvalidArgumentException(
+                "Field '{$handle}' is not a relation field; pass a scalar value, ':empty:', or ':notempty:'",
+            );
+        }
+
+        return $this->keys->idFor($field::elementType(), $value, $site)
+            ?? throw new InvalidArgumentException(
+                "No element found for the natural key in filters.{$handle}: " . json_encode($value),
+            );
+    }
+
+    /**
+     * @param array<string, string> $key
+     */
+    private function resolveRelatedTo(array $key, ?string $site): int {
+        foreach (self::RELATABLE_TYPES as $type) {
+            if (!$this->matchesShape($type, $key)) {
+                continue;
+            }
+
+            $id = $this->keys->idFor($type, $key, $site);
+            if ($id !== null) {
+                return $id;
+            }
+        }
+
+        throw new InvalidArgumentException(
+            'relatedTo did not match any element; expected a natural key like '
+            . '{"section","slug"}, {"volume","filename"}, {"group","slug"}, or {"username"}, got: '
+            . json_encode($key),
+        );
+    }
+
+    private function matchesShape(string $type, array $key): bool {
+        $shape = $this->keys->keyShape($type);
+        if ($shape === null) {
+            return false;
+        }
+
+        $required = array_filter($shape, static fn (string $part): bool => !str_ends_with($part, '?'));
+
+        return array_all($required, static fn (string $part): bool => isset($key[$part]));
+    }
+}

--- a/src/elements/query/Filters.php
+++ b/src/elements/query/Filters.php
@@ -102,12 +102,19 @@ final readonly class Filters {
     /**
      * A field filter value: scalars and :empty:/:notempty: pass through to
      * Craft's field query params; arrays are natural keys, resolved to the
-     * related element id (relation fields only). Craft reserves query-param
-     * names, so a validated field handle never collides with a query method.
+     * related element id (relation fields only). Handles that shadow a real
+     * query param would silently set that param instead of filtering the
+     * field, so they are refused outright.
      */
     private function fieldValue(string $handle, mixed $value, ?string $site): mixed {
         $field = Craft::$app->getFields()->getFieldByHandle($handle)
             ?? throw new InvalidArgumentException("Unknown field handle '{$handle}' in filters");
+
+        if (method_exists(EntryQuery::class, $handle) || property_exists(EntryQuery::class, $handle)) {
+            throw new InvalidArgumentException(
+                "Field handle '{$handle}' collides with an entry query parameter and cannot be used in filters; use search instead",
+            );
+        }
 
         if (!is_array($value)) {
             return $value;
@@ -147,6 +154,9 @@ final readonly class Filters {
         );
     }
 
+    /**
+     * @param array<string, string> $key
+     */
     private function matchesShape(string $type, array $key): bool {
         $shape = $this->keys->keyShape($type);
         if ($shape === null) {

--- a/src/elements/query/Projection.php
+++ b/src/elements/query/Projection.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\elements\query;
+
+use craft\elements\Entry;
+use InvalidArgumentException;
+use stimmt\craft\Mcp\elements\LayoutFields;
+use stimmt\craft\Mcp\elements\Reader;
+
+/**
+ * Slim list_entries rows: id and title always, plus only the requested
+ * attributes and field values. Keeps large-list analysis affordable where the
+ * full payload would drown the client.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final readonly class Projection {
+    public const array ATTRIBUTES = [
+        'slug', 'status', 'url', 'cpEditUrl', 'postDate', 'expiryDate',
+        'dateCreated', 'dateUpdated', 'sectionHandle', 'typeHandle', 'siteHandle', 'authorId',
+    ];
+
+    public function __construct(
+        private Reader $reader,
+    ) {
+    }
+
+    /**
+     * @param string[] $fields attribute names or field handles
+     */
+    public function row(Entry $entry, array $fields, ?string $site = null): array {
+        [$attributes, $handles] = $this->split($entry, $fields);
+
+        $row = ['id' => $entry->id, 'title' => $entry->title];
+        foreach ($attributes as $attribute) {
+            $row[$attribute] = $this->attribute($entry, $attribute);
+        }
+
+        if ($handles !== []) {
+            $row['fields'] = $this->reader->readFields($entry, $handles, $site);
+        }
+
+        return $row;
+    }
+
+    /**
+     * @param string[] $fields
+     * @return array{0: string[], 1: string[]}
+     */
+    private function split(Entry $entry, array $fields): array {
+        $layout = LayoutFields::of($entry->getFieldLayout());
+        $attributes = [];
+        $handles = [];
+
+        foreach ($fields as $name) {
+            match (true) {
+                in_array($name, self::ATTRIBUTES, true) => $attributes[] = $name,
+                isset($layout[$name]) => $handles[] = $name,
+                default => throw new InvalidArgumentException(
+                    "Unknown projection field '{$name}'. Attributes: " . implode(', ', self::ATTRIBUTES)
+                    . '. Field handles: ' . implode(', ', array_keys($layout)),
+                ),
+            };
+        }
+
+        return [$attributes, $handles];
+    }
+
+    private function attribute(Entry $entry, string $attribute): mixed {
+        return match ($attribute) {
+            'slug' => $entry->slug,
+            'status' => $entry->getStatus(),
+            'url' => $entry->getUrl(),
+            'cpEditUrl' => $entry->getCpEditUrl(),
+            'postDate' => $entry->postDate?->format('Y-m-d H:i:s'),
+            'expiryDate' => $entry->expiryDate?->format('Y-m-d H:i:s'),
+            'dateCreated' => $entry->dateCreated?->format('Y-m-d H:i:s'),
+            'dateUpdated' => $entry->dateUpdated?->format('Y-m-d H:i:s'),
+            'sectionHandle' => $entry->getSection()?->handle,
+            'typeHandle' => $entry->getType()->handle,
+            'siteHandle' => $entry->getSite()->handle,
+            'authorId' => $entry->getAuthorId(),
+            default => null,
+        };
+    }
+}

--- a/src/elements/query/Projection.php
+++ b/src/elements/query/Projection.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\elements\query;
 
 use craft\elements\Entry;
 use InvalidArgumentException;
+use stimmt\craft\Mcp\elements\Attributes;
 use stimmt\craft\Mcp\elements\LayoutFields;
 use stimmt\craft\Mcp\elements\Reader;
 
@@ -35,7 +36,7 @@ final readonly class Projection {
 
         $row = ['id' => $entry->id, 'title' => $entry->title];
         foreach ($attributes as $attribute) {
-            $row[$attribute] = $this->attribute($entry, $attribute);
+            $row[$attribute] = Attributes::value($entry, $attribute);
         }
 
         if ($handles !== []) {
@@ -66,23 +67,5 @@ final readonly class Projection {
         }
 
         return [$attributes, $handles];
-    }
-
-    private function attribute(Entry $entry, string $attribute): mixed {
-        return match ($attribute) {
-            'slug' => $entry->slug,
-            'status' => $entry->getStatus(),
-            'url' => $entry->getUrl(),
-            'cpEditUrl' => $entry->getCpEditUrl(),
-            'postDate' => $entry->postDate?->format('Y-m-d H:i:s'),
-            'expiryDate' => $entry->expiryDate?->format('Y-m-d H:i:s'),
-            'dateCreated' => $entry->dateCreated?->format('Y-m-d H:i:s'),
-            'dateUpdated' => $entry->dateUpdated?->format('Y-m-d H:i:s'),
-            'sectionHandle' => $entry->getSection()?->handle,
-            'typeHandle' => $entry->getType()->handle,
-            'siteHandle' => $entry->getSite()->handle,
-            'authorId' => $entry->getAuthorId(),
-            default => null,
-        };
     }
 }

--- a/src/prompts/ContentPrompts.php
+++ b/src/prompts/ContentPrompts.php
@@ -143,6 +143,7 @@ Please help me:
 3. Recommend tools to use (read_logs, get_last_error, get_deprecations, explain_query)
 4. Provide possible solutions or workarounds
 5. Identify if this might be a configuration, data, or code issue
+6. Work up the tool ladder: content tools first (list_entries filters, count_entries, list_revisions for "when did this change"), query_graphql for other element types, get_database_schema for structure, run_query for custom tables, tinker only when no tool can express it
 
 What additional information would you need to diagnose this issue?
 PROMPT);

--- a/src/prompts/EntryPrompts.php
+++ b/src/prompts/EntryPrompts.php
@@ -114,8 +114,8 @@ I need to query entries from this Craft CMS section:
 ```
 
 Please provide guidance on:
-1. How to use the list_entries tool effectively for this section, including the full-text 'search' and multi-site 'site' parameters
-2. Available filter parameters based on the field types
+1. How to use the list_entries tool effectively for this section, including full-text `search`, the `site` parameter, field-value `filters` (with :empty:/:notempty: and natural keys), `relatedTo`, date ranges, and the `fields` projection for slim rows
+2. When count_entries answers the question without listing anything (totals, per-value breakdowns, per-month trends via groupBy)
 3. Pagination strategies for the {$entryCount} entries
 4. Performance optimization tips
 5. Example queries for common use cases
@@ -160,7 +160,7 @@ Current state:
 - Entry types: {$entryTypes}
 
 Please help me understand:
-1. How to safely iterate through all entries using list_entries with pagination (and the search/site filters)
+1. How to scope the batch first: count_entries with the same filters shows exactly how many entries a bulk operation will touch, then list_entries with those filters (and a `fields` projection) iterates them
 2. How to batch update entries using update_entry: each write lands as a draft on top of the live entry, so nothing changes for visitors until publish_entry runs per entry
 3. How drafts double as the safety net: a wrong batch is discarded drafts, not corrupted live content; review spot checks via each response's cpEditUrl before publishing
 4. When duplicate_entry ("like X but change these") or copy_entry_to_site fits the job better than editing in place

--- a/src/services/McpServerFactory.php
+++ b/src/services/McpServerFactory.php
@@ -168,12 +168,16 @@ This MCP server provides access to a Craft CMS installation.
 
 The full contract lives in the `craft://guides/content-writing` resource.
 
-## Best Practices
+## Choosing Tools
 
-1. Use `list_*` tools to explore available data before making changes
-2. Use `get_*` tools to inspect specific items
-3. Use read-only queries before mutations
-4. Tools marked with a destructive annotation modify data or execute code; prefer draft-mode writes and review flows
+Prefer the most specific tool and escalate only when none fits:
+
+1. Content questions: `list_entries` (field filters, `relatedTo`, `search`, date ranges, `fields` projection), `get_entry`, `count_entries` for totals and per-value breakdowns, `list_drafts` for the review queue, `list_revisions` for an entry's history, `describe_entry_schema` for payload shapes.
+2. Other element types and nested shapes: `query_graphql` reads anything Craft's GraphQL schema exposes (assets, categories, users, plugin types) with exactly the response shape you ask for.
+3. Database structure: `get_database_schema` and `get_table_counts`, never hand-written information_schema queries.
+4. `run_query` covers what no structured tool does: custom plugin tables and aggregate SQL (SELECT only).
+5. `tinker` is the last resort, for logic no tool can express (cross-entry computation, service calls). Keep analysis code read-only; write content through the entry tools so drafts, validation, and warnings stay in play.
+6. Tools marked with a destructive annotation modify data or execute code; prefer draft-mode writes and review flows.
 INSTRUCTIONS;
     }
 

--- a/src/tools/AssetTools.php
+++ b/src/tools/AssetTools.php
@@ -11,6 +11,7 @@ use craft\models\VolumeFolder;
 use craft\services\Assets;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
@@ -29,6 +30,7 @@ class AssetTools {
     #[McpTool(
         name: 'list_assets',
         description: 'List assets from Craft CMS. Filter by volume, folder, kind (image, video, pdf, etc.), filename.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listAssets(
@@ -84,6 +86,7 @@ class AssetTools {
     #[McpTool(
         name: 'get_asset',
         description: 'Get a single asset by ID with full metadata',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function getAsset(int $id, ?RequestContext $context = null): array {
@@ -107,6 +110,7 @@ class AssetTools {
     #[McpTool(
         name: 'list_volumes',
         description: 'List all asset volumes (storage locations) in Craft CMS',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listVolumes(?RequestContext $context = null): array {
@@ -138,6 +142,7 @@ class AssetTools {
     #[McpTool(
         name: 'list_asset_folders',
         description: 'List asset folders in a volume',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listAssetFolders(?string $volume = null, ?int $parentId = null, ?RequestContext $context = null): array {

--- a/src/tools/BackupTools.php
+++ b/src/tools/BackupTools.php
@@ -25,6 +25,7 @@ class BackupTools {
     #[McpTool(
         name: 'list_backups',
         description: 'List available database backups from storage/backups directory',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::BACKUP)]
     public function listBackups(?RequestContext $context = null): array {

--- a/src/tools/CategoryTools.php
+++ b/src/tools/CategoryTools.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\tools;
 
 use craft\elements\Category;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
@@ -24,6 +25,7 @@ class CategoryTools {
     #[McpTool(
         name: 'list_categories',
         description: 'List categories from Craft CMS. Filter by group handle.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listCategories(?string $group = null, int $limit = 100, ?RequestContext $context = null): array {

--- a/src/tools/CommerceTools.php
+++ b/src/tools/CommerceTools.php
@@ -10,6 +10,7 @@ use craft\commerce\elements\Product;
 use craft\commerce\Plugin as Commerce;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\contracts\ConditionalToolProvider;
@@ -62,6 +63,7 @@ class CommerceTools implements ConditionalToolProvider {
     #[McpTool(
         name: 'list_products',
         description: 'List products from Craft Commerce. Filter by product type handle.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::COMMERCE)]
     public function listProducts(
@@ -100,6 +102,7 @@ class CommerceTools implements ConditionalToolProvider {
     #[McpTool(
         name: 'get_product',
         description: 'Get detailed information about a single Commerce product by ID',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::COMMERCE)]
     public function getProduct(int $id, ?RequestContext $context = null): array {
@@ -158,6 +161,7 @@ class CommerceTools implements ConditionalToolProvider {
     #[McpTool(
         name: 'list_orders',
         description: 'List orders from Craft Commerce. Filter by status handle.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::COMMERCE)]
     public function listOrders(
@@ -212,6 +216,7 @@ class CommerceTools implements ConditionalToolProvider {
     #[McpTool(
         name: 'get_order',
         description: 'Get detailed information about a single Commerce order by ID or order number',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::COMMERCE)]
     public function getOrder(?int $id = null, ?string $number = null, ?RequestContext $context = null): array {
@@ -297,6 +302,7 @@ class CommerceTools implements ConditionalToolProvider {
     #[McpTool(
         name: 'list_order_statuses',
         description: 'List all order statuses configured in Craft Commerce',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::COMMERCE)]
     public function listOrderStatuses(?RequestContext $context = null): array {
@@ -333,6 +339,7 @@ class CommerceTools implements ConditionalToolProvider {
     #[McpTool(
         name: 'list_product_types',
         description: 'List all product types configured in Craft Commerce',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::COMMERCE)]
     public function listProductTypes(?RequestContext $context = null): array {

--- a/src/tools/CraftTools.php
+++ b/src/tools/CraftTools.php
@@ -8,6 +8,7 @@ use Craft;
 use craft\base\FieldInterface;
 use craft\models\Section;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
@@ -28,6 +29,7 @@ class CraftTools {
     #[McpTool(
         name: 'list_plugins',
         description: 'List all installed Craft CMS plugins with their enabled status, version, and handle',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SCHEMA)]
     public function listPlugins(?RequestContext $context = null): array {
@@ -62,6 +64,7 @@ class CraftTools {
     #[McpTool(
         name: 'list_sections',
         description: 'List all sections (channels, structures, singles) in Craft CMS with their entry types. Optionally filter by handle/name search term.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SCHEMA)]
     public function listSections(?string $search = null, ?RequestContext $context = null): array {
@@ -117,6 +120,7 @@ class CraftTools {
     #[McpTool(
         name: 'get_system_info',
         description: 'Get information about the Craft CMS installation including version, PHP version, and database info',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SYSTEM)]
     public function getSystemInfo(?RequestContext $context = null): array {
@@ -159,6 +163,7 @@ class CraftTools {
     #[McpTool(
         name: 'list_fields',
         description: 'List all custom fields in Craft CMS with their type and group. Optionally filter by handle/name search term or field type.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SCHEMA)]
     public function listFields(?string $search = null, ?string $type = null, ?RequestContext $context = null): array {

--- a/src/tools/DatabaseTools.php
+++ b/src/tools/DatabaseTools.php
@@ -129,7 +129,7 @@ class DatabaseTools {
      */
     #[McpTool(
         name: 'run_query',
-        description: 'Execute a read-only SQL query (SELECT only). WARNING: Basic keyword security - for development only. May be bypassable with certain PDO configs.',
+        description: 'Execute a read-only SQL query (SELECT only). Best for custom plugin tables and aggregate SQL; for table and column discovery use get_database_schema, and for entry content prefer list_entries/count_entries. WARNING: Basic keyword security - for development only. May be bypassable with certain PDO configs.',
         annotations: new ToolAnnotations(destructiveHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DATABASE, dangerous: true)]

--- a/src/tools/DatabaseTools.php
+++ b/src/tools/DatabaseTools.php
@@ -28,6 +28,7 @@ class DatabaseTools {
     #[McpTool(
         name: 'get_database_schema',
         description: 'Get database schema information. Lists all tables, or details for a specific table including columns and indexes.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DATABASE)]
     public function getDatabaseSchema(?string $table = null, ?RequestContext $context = null): array {
@@ -162,6 +163,7 @@ class DatabaseTools {
     #[McpTool(
         name: 'get_database_info',
         description: 'Get database connection information including driver, server version, and connection details',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DATABASE)]
     public function getDatabaseInfo(?RequestContext $context = null): array {
@@ -187,6 +189,7 @@ class DatabaseTools {
     #[McpTool(
         name: 'get_table_counts',
         description: 'Get row counts for Craft CMS tables (entries, assets, users, etc.)',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DATABASE)]
     public function getTableCounts(?RequestContext $context = null): array {

--- a/src/tools/DebugTools.php
+++ b/src/tools/DebugTools.php
@@ -9,6 +9,7 @@ use Craft;
 use Generator;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use ReflectionClass;
 use ReflectionFunction;
@@ -32,6 +33,7 @@ class DebugTools {
     #[McpTool(
         name: 'get_queue_jobs',
         description: 'List queue jobs in Craft CMS. Filter by status: pending, reserved, failed, done. Shows job class, description, and failure reason if applicable.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DEBUGGING)]
     public function getQueueJobs(string $status = 'pending', int $limit = 50, ?RequestContext $context = null): array {
@@ -107,6 +109,7 @@ class DebugTools {
     #[McpTool(
         name: 'get_project_config_diff',
         description: 'Show pending project config changes that need to be applied. Returns differences between YAML files and database.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DEBUGGING)]
     public function getProjectConfigDiff(?RequestContext $context = null): array {
@@ -164,6 +167,7 @@ class DebugTools {
     #[McpTool(
         name: 'get_deprecations',
         description: 'Get deprecation warnings from Craft CMS logs. Shows deprecated code usage that should be updated.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DEBUGGING)]
     public function getDeprecations(int $limit = 50, ?RequestContext $context = null): array {
@@ -238,6 +242,7 @@ class DebugTools {
     #[McpTool(
         name: 'explain_query',
         description: 'Run EXPLAIN on a SELECT query to analyze performance. Shows query execution plan, indexes used, and estimated rows.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DEBUGGING)]
     public function explainQuery(string $sql, ?RequestContext $context = null): array {
@@ -283,6 +288,7 @@ class DebugTools {
     #[McpTool(
         name: 'get_environment',
         description: 'Get safe environment information (no secrets). Shows CRAFT_ENVIRONMENT, PHP settings, and system status.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DEBUGGING)]
     public function getEnvironment(?RequestContext $context = null): array {
@@ -342,6 +348,7 @@ class DebugTools {
     #[McpTool(
         name: 'list_event_handlers',
         description: 'List registered event handlers/listeners in Craft CMS. Useful for debugging hooks and understanding what code runs on events.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DEBUGGING)]
     public function listEventHandlers(?string $filter = null, ?RequestContext $context = null): array {

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -8,10 +8,12 @@ use Craft;
 use craft\elements\Entry;
 use craft\elements\User;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
 use Mcp\Exception\ToolCallException;
 use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\elements\query\Filters;
 use stimmt\craft\Mcp\elements\Reader;
 use stimmt\craft\Mcp\elements\refs\Keys;
 use stimmt\craft\Mcp\elements\schema\Describer;
@@ -37,15 +39,19 @@ class EntryTools {
 
     private readonly Keys $keys;
 
-    public function __construct(?Reader $reader = null, ?Writer $writer = null, ?Keys $keys = null) {
+    private readonly Filters $filters;
+
+    public function __construct(?Reader $reader = null, ?Writer $writer = null, ?Keys $keys = null, ?Filters $filters = null) {
         $this->reader = $reader ?? ElementModule::reader();
         $this->writer = $writer ?? ElementModule::writer();
         $this->keys = $keys ?? new Keys();
+        $this->filters = $filters ?? new Filters();
     }
 
     #[McpTool(
         name: 'list_entries',
-        description: 'List entries. Filter by section, type, status, site handle, and full-text search. Returns entries in the payload format (natural keys for relations).',
+        description: 'List entries. Filter by section, type, status, site, full-text search, field values (with :empty:/:notempty: and natural keys for relations), relatedTo, author, and date ranges. Returns entries in the payload format (natural keys for relations).',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listEntries(
@@ -54,11 +60,20 @@ class EntryTools {
         ?string $status = null,
         ?string $site = null,
         ?string $search = null,
+        #[Schema(type: 'object', description: 'Field-value filters: {fieldHandle: value}. Values are scalars, ":empty:", ":notempty:", or a natural key object for relation fields (e.g. {"group": "...", "slug": "..."}).', additionalProperties: true)]
+        ?array $filters = null,
+        #[Schema(type: 'object', description: 'Only entries related to this element, as a natural key: {"section","slug"}, {"volume","filename"}, {"group","slug"}, or {"username"}.', additionalProperties: true)]
+        ?array $relatedTo = null,
+        ?string $author = null,
+        ?string $updatedAfter = null,
+        ?string $updatedBefore = null,
+        ?string $createdAfter = null,
+        ?string $createdBefore = null,
         int $limit = 20,
         int $offset = 0,
         ?RequestContext $context = null,
     ): array {
-        return SafeExecution::run(function () use ($section, $type, $status, $site, $search, $limit, $offset): array {
+        return SafeExecution::run(function () use ($section, $type, $status, $site, $search, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $limit, $offset): array {
             SiteResolver::resolve($site);
 
             $query = Entry::find()->limit($limit)->offset($offset);
@@ -67,6 +82,8 @@ class EntryTools {
                     $query->$method($value);
                 }
             }
+
+            $this->filters->apply($query, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $site);
 
             $results = array_map(fn (Entry $entry): array => $this->reader->read($entry, $site), $query->all());
 
@@ -77,6 +94,7 @@ class EntryTools {
     #[McpTool(
         name: 'get_entry',
         description: 'Get one entry by id or slug, in the payload format: what this returns is exactly what create_entry/update_entry accept as fields.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function getEntry(
@@ -183,6 +201,7 @@ class EntryTools {
     #[McpTool(
         name: 'describe_entry_schema',
         description: 'Describe the fields a section/entry type accepts: handles, kinds, required flags, a per-field input shape (the exact payload each field takes: natural keys for relations, block types for matrix, link/option/table/container shapes for structured and third-party fields), native fields, writable meta attributes. Pass example (entry id or slug) to include a real entry payload as a golden fixture.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SCHEMA)]
     public function describeEntrySchema(

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -13,6 +13,7 @@ use Mcp\Exception\ToolCallException;
 use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\elements\query\Buckets;
 use stimmt\craft\Mcp\elements\query\Filters;
 use stimmt\craft\Mcp\elements\query\Projection;
 use stimmt\craft\Mcp\elements\Reader;
@@ -96,6 +97,49 @@ class EntryTools {
                 : array_map(fn (Entry $entry): array => $this->projection->row($entry, $fields, $site), $query->all());
 
             return Response::paginated('entries', $results, (int) $query->count(), $limit, $offset);
+        });
+    }
+
+    #[McpTool(
+        name: 'count_entries',
+        description: 'Count entries, optionally grouped: by attribute (status, type, section, site, author), by date bucket ("month:dateUpdated", day|week|month|year with dateCreated|dateUpdated|postDate), or by a field handle (relation fields bucket by related title, empty values under "(empty)"). Same filters as list_entries. One call answers "how many per X" without listing anything.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
+    )]
+    #[McpToolMeta(category: ToolCategory::CONTENT)]
+    public function countEntries(
+        ?string $section = null,
+        ?string $type = null,
+        ?string $status = null,
+        ?string $site = null,
+        ?string $search = null,
+        #[Schema(type: 'object', description: 'Field-value filters: {fieldHandle: value}. Values are scalars, ":empty:", ":notempty:", or a natural key object for relation fields.', additionalProperties: true)]
+        ?array $filters = null,
+        #[Schema(type: 'object', description: 'Only entries related to this element, as a natural key.', additionalProperties: true)]
+        ?array $relatedTo = null,
+        ?string $author = null,
+        ?string $updatedAfter = null,
+        ?string $updatedBefore = null,
+        ?string $createdAfter = null,
+        ?string $createdBefore = null,
+        ?string $groupBy = null,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($section, $type, $status, $site, $search, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $groupBy): array {
+            SiteResolver::resolve($site);
+
+            $query = Entry::find()->status($status);
+            foreach (['section' => $section, 'type' => $type, 'site' => $site, 'search' => $search] as $method => $value) {
+                if ($value !== null) {
+                    $query->$method($value);
+                }
+            }
+
+            $this->filters->apply($query, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $site);
+
+            $result = (new Buckets())->collect($query, $groupBy);
+            $result['groupBy'] = $groupBy;
+
+            return Response::success($result);
         });
     }
 

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -14,6 +14,7 @@ use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\elements\query\Filters;
+use stimmt\craft\Mcp\elements\query\Projection;
 use stimmt\craft\Mcp\elements\Reader;
 use stimmt\craft\Mcp\elements\refs\Keys;
 use stimmt\craft\Mcp\elements\schema\Describer;
@@ -41,11 +42,14 @@ class EntryTools {
 
     private readonly Filters $filters;
 
-    public function __construct(?Reader $reader = null, ?Writer $writer = null, ?Keys $keys = null, ?Filters $filters = null) {
+    private readonly Projection $projection;
+
+    public function __construct(?Reader $reader = null, ?Writer $writer = null, ?Keys $keys = null, ?Filters $filters = null, ?Projection $projection = null) {
         $this->reader = $reader ?? ElementModule::reader();
         $this->writer = $writer ?? ElementModule::writer();
         $this->keys = $keys ?? new Keys();
         $this->filters = $filters ?? new Filters();
+        $this->projection = $projection ?? new Projection($this->reader);
     }
 
     #[McpTool(
@@ -69,11 +73,13 @@ class EntryTools {
         ?string $updatedBefore = null,
         ?string $createdAfter = null,
         ?string $createdBefore = null,
+        #[Schema(type: 'array', description: 'Projection: return only these attributes and field handles per entry (id and title always included) instead of the full payload. Ideal for scanning many entries.', items: ['type' => 'string'])]
+        ?array $fields = null,
         int $limit = 20,
         int $offset = 0,
         ?RequestContext $context = null,
     ): array {
-        return SafeExecution::run(function () use ($section, $type, $status, $site, $search, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $limit, $offset): array {
+        return SafeExecution::run(function () use ($section, $type, $status, $site, $search, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $fields, $limit, $offset): array {
             SiteResolver::resolve($site);
 
             $query = Entry::find()->limit($limit)->offset($offset);
@@ -85,7 +91,9 @@ class EntryTools {
 
             $this->filters->apply($query, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $site);
 
-            $results = array_map(fn (Entry $entry): array => $this->reader->read($entry, $site), $query->all());
+            $results = $fields === null
+                ? array_map(fn (Entry $entry): array => $this->reader->read($entry, $site), $query->all())
+                : array_map(fn (Entry $entry): array => $this->projection->row($entry, $fields, $site), $query->all());
 
             return Response::paginated('entries', $results, (int) $query->count(), $limit, $offset);
         });

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -304,9 +304,10 @@ class EntryTools {
 
         $query = Entry::find()->status(null);
         if ($id !== null) {
-            // An id lookup must find drafts too: agents read back the draft
-            // a write just created. drafts(null) matches both.
-            $query->drafts(null);
+            // An id lookup must find drafts and revisions too: agents read
+            // back the draft a write just created, and revision ids come from
+            // list_revisions. null matches both states.
+            $query->drafts(null)->revisions(null);
         }
 
         foreach (['id' => $id, 'slug' => $slug, 'section' => $section, 'site' => $site] as $method => $value) {

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -84,7 +84,12 @@ class EntryTools {
             SiteResolver::resolve($site);
 
             $query = Entry::find()->limit($limit)->offset($offset);
-            foreach (['section' => $section, 'type' => $type, 'status' => $status, 'site' => $site, 'search' => $search] as $method => $value) {
+
+            if ($status !== null) {
+                $query->status($status === 'any' ? null : $status);
+            }
+
+            foreach (['section' => $section, 'type' => $type, 'site' => $site, 'search' => $search] as $method => $value) {
                 if ($value !== null) {
                     $query->$method($value);
                 }
@@ -102,7 +107,7 @@ class EntryTools {
 
     #[McpTool(
         name: 'count_entries',
-        description: 'Count entries, optionally grouped: by attribute (status, type, section, site, author), by date bucket ("month:dateUpdated", day|week|month|year with dateCreated|dateUpdated|postDate), or by a field handle (relation fields bucket by related title, empty values under "(empty)"). Same filters as list_entries. One call answers "how many per X" without listing anything.',
+        description: 'Count entries, optionally grouped: by attribute (status, type, section, site, author), by date bucket ("month:dateUpdated", day|week|month|year with dateCreated|dateUpdated|postDate), or by a field handle (relation fields bucket by related title, empty values under "(empty)"). Same filters as list_entries. Counts include EVERY status by default (list_entries defaults to live only); pass status to narrow. One call answers "how many per X" without listing anything.',
         annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
@@ -127,7 +132,7 @@ class EntryTools {
         return SafeExecution::run(function () use ($section, $type, $status, $site, $search, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $groupBy): array {
             SiteResolver::resolve($site);
 
-            $query = Entry::find()->status($status);
+            $query = Entry::find()->status($status === 'any' ? null : $status);
             foreach (['section' => $section, 'type' => $type, 'site' => $site, 'search' => $search] as $method => $value) {
                 if ($value !== null) {
                     $query->$method($value);

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\tools;
 
 use Craft;
 use craft\behaviors\DraftBehavior;
+use craft\behaviors\RevisionBehavior;
 use craft\elements\Entry;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
@@ -75,6 +76,39 @@ class EntryWorkflowTools {
             $drafts = array_map($this->draftSummary(...), $query->all());
 
             return Response::paginated('drafts', $drafts, (int) $query->count(), $limit, $offset);
+        });
+    }
+
+    #[McpTool(
+        name: 'list_revisions',
+        description: 'List an entry\'s saved revisions, newest first: who saved each one, when, and with what notes. Answers "when did this change and by whom". Read a revision\'s full content with get_entry using its revisionElementId; the canonical entry id always holds the current content.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
+    )]
+    #[McpToolMeta(category: ToolCategory::CONTENT)]
+    public function listRevisions(
+        int $id,
+        ?string $site = null,
+        int $limit = 20,
+        int $offset = 0,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($id, $site, $limit, $offset): array {
+            SiteResolver::resolve($site);
+
+            $query = Entry::find()
+                ->revisionOf($id)
+                ->revisions()
+                ->status(null)
+                ->limit($limit)
+                ->offset($offset)
+                ->orderBy(['dateCreated' => SORT_DESC]);
+            if ($site !== null) {
+                $query->site($site);
+            }
+
+            $revisions = array_map($this->revisionSummary(...), $query->all());
+
+            return Response::paginated('revisions', $revisions, (int) $query->count(), $limit, $offset);
         });
     }
 
@@ -197,6 +231,29 @@ class EntryWorkflowTools {
             'notes' => $notes,
             'dateUpdated' => $draft->dateUpdated?->format('Y-m-d H:i:s'),
             'cpEditUrl' => $draft->getCpEditUrl(),
+        ];
+    }
+
+    /**
+     * One history row: identifiers, the human trail (creator, notes), and the
+     * timestamp the revision was saved.
+     *
+     * @return array<string, mixed>
+     */
+    private function revisionSummary(Entry $revision): array {
+        $behavior = $revision->getBehavior('revision');
+        $creator = $behavior instanceof RevisionBehavior ? $behavior->getCreator() : null;
+        $notes = $behavior instanceof RevisionBehavior ? $behavior->revisionNotes : null;
+        $num = $behavior instanceof RevisionBehavior ? $behavior->revisionNum : null;
+
+        return [
+            'revisionElementId' => (int) $revision->id,
+            'canonicalId' => (int) $revision->getCanonicalId(),
+            'revisionNum' => $num,
+            'title' => (string) $revision->title,
+            'creator' => $creator?->username,
+            'notes' => $notes,
+            'dateCreated' => $revision->dateCreated?->format('Y-m-d H:i:s'),
         ];
     }
 

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -40,6 +40,7 @@ class EntryWorkflowTools {
     #[McpTool(
         name: 'list_drafts',
         description: 'List pending (non-provisional) entry drafts awaiting review, newest first. Filter by section, site, or creator username/email. Each row carries the draft element id publish_entry accepts and a cpEditUrl for human review.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listDrafts(

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -102,7 +102,7 @@ class EntryWorkflowTools {
                 ->status(null)
                 ->limit($limit)
                 ->offset($offset)
-                ->orderBy(['dateCreated' => SORT_DESC]);
+                ->orderBy(['dateCreated' => SORT_DESC, 'revisions.num' => SORT_DESC]);
             if ($site !== null) {
                 $query->site($site);
             }

--- a/src/tools/GlobalSetTools.php
+++ b/src/tools/GlobalSetTools.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\tools;
 
 use Craft;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
@@ -25,6 +26,7 @@ class GlobalSetTools {
     #[McpTool(
         name: 'list_globals',
         description: 'List all global sets in Craft CMS with their field values',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listGlobals(?RequestContext $context = null): array {

--- a/src/tools/GraphqlTools.php
+++ b/src/tools/GraphqlTools.php
@@ -6,6 +6,9 @@ namespace stimmt\craft\Mcp\tools;
 
 use Craft;
 use craft\models\GqlSchema;
+use GraphQL\Error\SyntaxError;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\Parser;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
 use Mcp\Schema\ToolAnnotations;
@@ -102,6 +105,29 @@ class GraphqlTools {
     }
 
     /**
+     * Run a read-only GraphQL query.
+     */
+    #[McpTool(
+        name: 'query_graphql',
+        description: 'Run a read-only GraphQL query against Craft\'s GraphQL API. Mutations and subscriptions are rejected before execution, so this is safe for browsing any GraphQL-exposed data (assets, categories, users, plugin types) with exactly the response shape you ask for. Use get_graphql_schema to discover the available types first.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
+    )]
+    #[McpToolMeta(category: ToolCategory::GRAPHQL)]
+    public function queryGraphql(
+        string $query,
+        ?string $variables = null,
+        ?string $operationName = null,
+        ?int $schemaId = null,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($query, $variables, $operationName, $schemaId, $context): array {
+            $this->assertReadOnly($query);
+
+            return $this->execute($query, $variables, $operationName, $schemaId, $context);
+        });
+    }
+
+    /**
      * Execute a GraphQL query.
      */
     #[McpTool(
@@ -117,46 +143,71 @@ class GraphqlTools {
         ?int $schemaId = null,
         ?RequestContext $context = null,
     ): array {
-        return SafeExecution::run(function () use ($query, $variables, $operationName, $schemaId, $context): array {
-            $context?->getClientGateway()?->progress(0, 2, 'Executing GraphQL query...');
+        return SafeExecution::run(fn (): array => $this->execute($query, $variables, $operationName, $schemaId, $context));
+    }
 
-            $gql = Craft::$app->getGql();
+    /**
+     * Mutations are rejected at the AST level, before any execution: this is
+     * what lets query_graphql stay out of the dangerous-tools gate.
+     */
+    private function assertReadOnly(string $query): void {
+        try {
+            $document = Parser::parse($query);
+        } catch (SyntaxError $e) {
+            throw new ToolCallException('GraphQL syntax error: ' . $e->getMessage(), $e->getCode(), $e);
+        }
 
-            // Get the schema to use
-            $schema = $schemaId !== null
-                ? $gql->getSchemaById($schemaId)
-                : $gql->getPublicSchema();
-
-            if ($schema === null) {
-                $error = $schemaId !== null
-                    ? "Schema with ID {$schemaId} not found"
-                    : 'No public schema available. Provide a schemaId.';
-
-                throw new ToolCallException($error);
+        foreach ($document->definitions as $definition) {
+            if ($definition instanceof OperationDefinitionNode && $definition->operation !== 'query') {
+                throw new ToolCallException(
+                    "Only query operations are allowed here; '{$definition->operation}' requires execute_graphql (dangerous tools)",
+                );
             }
+        }
+    }
 
-            // Parse variables if provided
-            $parsedVariables = $this->parseVariables($variables);
-            if ($parsedVariables === false) {
-                throw new ToolCallException('Invalid JSON in variables: ' . json_last_error_msg());
-            }
+    /**
+     * @return array{success: bool, data: mixed, errors: mixed}
+     */
+    private function execute(string $query, ?string $variables, ?string $operationName, ?int $schemaId, ?RequestContext $context): array {
+        $context?->getClientGateway()?->progress(0, 2, 'Executing GraphQL query...');
 
-            // Execute the query
-            $result = $gql->executeQuery(
-                $schema,
-                $query,
-                $parsedVariables,
-                $operationName,
-            );
+        $gql = Craft::$app->getGql();
 
-            $context?->getClientGateway()?->progress(2, 2, 'Query complete');
+        // Get the schema to use
+        $schema = $schemaId !== null
+            ? $gql->getSchemaById($schemaId)
+            : $gql->getPublicSchema();
 
-            return [
-                'success' => true,
-                'data' => $result['data'] ?? null,
-                'errors' => $result['errors'] ?? null,
-            ];
-        });
+        if ($schema === null) {
+            $error = $schemaId !== null
+                ? "Schema with ID {$schemaId} not found"
+                : 'No public schema available. Provide a schemaId.';
+
+            throw new ToolCallException($error);
+        }
+
+        // Parse variables if provided
+        $parsedVariables = $this->parseVariables($variables);
+        if ($parsedVariables === false) {
+            throw new ToolCallException('Invalid JSON in variables: ' . json_last_error_msg());
+        }
+
+        // Execute the query
+        $result = $gql->executeQuery(
+            $schema,
+            $query,
+            $parsedVariables,
+            $operationName,
+        );
+
+        $context?->getClientGateway()?->progress(2, 2, 'Query complete');
+
+        return [
+            'success' => true,
+            'data' => $result['data'] ?? null,
+            'errors' => $result['errors'] ?? null,
+        ];
     }
 
     /**

--- a/src/tools/GraphqlTools.php
+++ b/src/tools/GraphqlTools.php
@@ -30,6 +30,7 @@ class GraphqlTools {
     #[McpTool(
         name: 'list_graphql_schemas',
         description: 'List all GraphQL schemas in Craft CMS with their scopes and permissions',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::GRAPHQL)]
     public function listGraphqlSchemas(?RequestContext $context = null): array {
@@ -64,6 +65,7 @@ class GraphqlTools {
     #[McpTool(
         name: 'get_graphql_schema',
         description: 'Get detailed information about a specific GraphQL schema including its SDL (Schema Definition Language)',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::GRAPHQL)]
     public function getGraphqlSchema(?int $id = null, ?string $uid = null, ?RequestContext $context = null): array {
@@ -216,6 +218,7 @@ class GraphqlTools {
     #[McpTool(
         name: 'list_graphql_tokens',
         description: 'List all GraphQL tokens (API keys) with their associated schemas',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::GRAPHQL)]
     public function listGraphqlTokens(?RequestContext $context = null): array {

--- a/src/tools/McpTools.php
+++ b/src/tools/McpTools.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\tools;
 
 use Craft;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
@@ -26,6 +27,7 @@ class McpTools {
     #[McpTool(
         name: 'get_mcp_info',
         description: 'Get information about the Craft MCP plugin including version, status, and configuration',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CORE)]
     public function getMcpInfo(?RequestContext $context = null): array {
@@ -66,6 +68,7 @@ class McpTools {
     #[McpTool(
         name: 'list_mcp_tools',
         description: 'List all available MCP tools with their names, descriptions, and enabled status',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CORE)]
     public function listMcpTools(?RequestContext $context = null): array {

--- a/src/tools/SiteTools.php
+++ b/src/tools/SiteTools.php
@@ -7,6 +7,7 @@ namespace stimmt\craft\Mcp\tools;
 use Craft;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Exception\ToolCallException;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
@@ -24,6 +25,7 @@ class SiteTools {
     #[McpTool(
         name: 'list_sites',
         description: 'List all sites in Craft CMS with their handles, languages, and configuration',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::MULTISITE)]
     public function listSites(?RequestContext $context = null): array {
@@ -61,6 +63,7 @@ class SiteTools {
     #[McpTool(
         name: 'get_site',
         description: 'Get detailed information about a specific site by ID or handle',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::MULTISITE)]
     public function getSite(?int $id = null, ?string $handle = null, ?RequestContext $context = null): array {
@@ -112,6 +115,7 @@ class SiteTools {
     #[McpTool(
         name: 'list_site_groups',
         description: 'List all site groups in Craft CMS',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::MULTISITE)]
     public function listSiteGroups(?RequestContext $context = null): array {

--- a/src/tools/SystemTools.php
+++ b/src/tools/SystemTools.php
@@ -33,6 +33,7 @@ class SystemTools {
     #[McpTool(
         name: 'get_config',
         description: 'Get a Craft CMS configuration value by dot-notation key (e.g., "general.devMode", "db.driver")',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SYSTEM)]
     public function getConfig(string $key, ?RequestContext $context = null): array {
@@ -73,6 +74,7 @@ class SystemTools {
     #[McpTool(
         name: 'read_logs',
         description: 'Read recent log entries from Craft CMS logs. Filter by source (web, console, queue, or plugin name), level (error, warning, info), pattern (case-insensitive search), and limit. Use output=text for human-readable colored output.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SYSTEM)]
     public function readLogs(
@@ -135,6 +137,7 @@ class SystemTools {
     #[McpTool(
         name: 'get_last_error',
         description: 'Get the most recent error from Craft CMS log files',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SYSTEM)]
     public function getLastError(?RequestContext $context = null): array {
@@ -202,6 +205,7 @@ class SystemTools {
     #[McpTool(
         name: 'list_console_commands',
         description: 'List all available Craft CMS console commands (like php craft <command>)',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SYSTEM)]
     public function listConsoleCommands(?RequestContext $context = null): array {
@@ -222,6 +226,7 @@ class SystemTools {
     #[McpTool(
         name: 'list_routes',
         description: 'List all registered routes in Craft CMS',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SYSTEM)]
     public function listRoutes(?RequestContext $context = null): array {

--- a/src/tools/TinkerTools.php
+++ b/src/tools/TinkerTools.php
@@ -79,7 +79,7 @@ class TinkerTools {
      */
     #[McpTool(
         name: 'tinker',
-        description: 'Execute PHP code within Craft CMS context. WARNING: Basic blocklist security only - not a secure sandbox. For development use only. Has access to Craft::$app and all services.',
+        description: 'Execute PHP code within Craft CMS context. Prefer a specific tool when one exists (content, schema, database tools); reach for tinker when none can express the job, such as cross-entry computation. WARNING: Basic blocklist security only - not a secure sandbox. For development use only. Has access to Craft::$app and all services.',
         annotations: new ToolAnnotations(destructiveHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DEBUGGING, dangerous: true)]

--- a/src/tools/UserTools.php
+++ b/src/tools/UserTools.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\tools;
 
 use craft\elements\User;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\enums\ToolCategory;
@@ -24,6 +25,7 @@ class UserTools {
     #[McpTool(
         name: 'list_users',
         description: 'List users from Craft CMS. Filter by group handle, status, email.',
+        annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT)]
     public function listUsers(

--- a/tests/Unit/Elements/AttributesTest.php
+++ b/tests/Unit/Elements/AttributesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\elements\Attributes;
+use stimmt\craft\Mcp\elements\query\Projection;
+use stimmt\craft\Mcp\elements\Reader;
+
+describe('Attributes', function () {
+    it('rejects unknown attribute names', function () {
+        $source = (string) file_get_contents((new ReflectionClass(Attributes::class))->getFileName());
+
+        expect($source)->toContain('Unknown attribute');
+    });
+
+    it('is the only place that formats payload dates', function () {
+        foreach ([Reader::class, Projection::class] as $class) {
+            $source = (string) file_get_contents((new ReflectionClass($class))->getFileName());
+
+            expect($source)->not->toContain("'Y-m-d H:i:s'");
+        }
+    });
+});

--- a/tests/Unit/Elements/Query/BucketsTest.php
+++ b/tests/Unit/Elements/Query/BucketsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\elements\query\Buckets;
+
+describe('Buckets::parseGroupBy', function () {
+    it('recognizes attribute targets', function (string $input) {
+        expect(Buckets::parseGroupBy($input))
+            ->toBe(['kind' => 'attribute', 'target' => $input, 'granularity' => null]);
+    })->with([['status'], ['type'], ['section'], ['site'], ['author']]);
+
+    it('parses date buckets', function () {
+        expect(Buckets::parseGroupBy('month:dateUpdated'))
+            ->toBe(['kind' => 'date', 'target' => 'dateUpdated', 'granularity' => 'month']);
+    });
+
+    it('rejects unknown date attributes and granularities', function (string $input) {
+        Buckets::parseGroupBy($input);
+    })->with([['month:expiryDate'], ['hour:dateUpdated']])
+        ->throws(InvalidArgumentException::class);
+
+    it('treats anything else as a field handle', function () {
+        expect(Buckets::parseGroupBy('vehicleType'))
+            ->toBe(['kind' => 'field', 'target' => 'vehicleType', 'granularity' => null]);
+    });
+});
+
+describe('Buckets::dateKey', function () {
+    $date = new DateTimeImmutable('2026-07-14 10:30:00');
+
+    it('formats each granularity', function (string $granularity, string $expected) use ($date) {
+        expect(Buckets::dateKey($date, $granularity))->toBe($expected);
+    })->with([
+        ['day', '2026-07-14'],
+        ['week', '2026-W29'],
+        ['month', '2026-07'],
+        ['year', '2026'],
+    ]);
+
+    it('buckets null dates as empty', function () {
+        expect(Buckets::dateKey(null, 'month'))->toBe('(empty)');
+    });
+});

--- a/tests/Unit/Elements/Query/BucketsTest.php
+++ b/tests/Unit/Elements/Query/BucketsTest.php
@@ -42,3 +42,12 @@ describe('Buckets::dateKey', function () {
         expect(Buckets::dateKey(null, 'month'))->toBe('(empty)');
     });
 });
+
+describe('Buckets eager loading', function () {
+    it('eager-loads relation fields across all statuses', function () {
+        $source = (string) file_get_contents((new ReflectionClass(Buckets::class))->getFileName());
+
+        expect($source)->toContain("['status' => null]")
+            ->and($source)->toContain('EagerLoadingFieldInterface');
+    });
+});

--- a/tests/Unit/Elements/Query/FiltersTest.php
+++ b/tests/Unit/Elements/Query/FiltersTest.php
@@ -50,4 +50,10 @@ describe('Filters structure', function () {
             ->and($source)->toContain('getFieldByHandle(')
             ->and($source)->toContain('InvalidArgumentException');
     });
+
+    it('refuses field handles that collide with query params', function () {
+        $source = (string) file_get_contents((new ReflectionClass(Filters::class))->getFileName());
+
+        expect($source)->toContain('collides with an entry query parameter');
+    });
 });

--- a/tests/Unit/Elements/Query/FiltersTest.php
+++ b/tests/Unit/Elements/Query/FiltersTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use craft\elements\db\EntryQuery;
+use stimmt\craft\Mcp\elements\query\Filters;
+
+describe('Filters::dateParam', function () {
+    it('returns null when both bounds are null', function () {
+        expect(Filters::dateParam(null, null))->toBeNull();
+    });
+
+    it('builds a lower bound only', function () {
+        expect(Filters::dateParam('2026-07-01', null))->toBe(['and', '>= 2026-07-01']);
+    });
+
+    it('builds an upper bound only', function () {
+        expect(Filters::dateParam(null, '2026-08-01'))->toBe(['and', '< 2026-08-01']);
+    });
+
+    it('builds both bounds', function () {
+        expect(Filters::dateParam('2026-07-01', '2026-08-01'))
+            ->toBe(['and', '>= 2026-07-01', '< 2026-08-01']);
+    });
+});
+
+describe('Filters structure', function () {
+    it('exposes apply with the shared filter parameters', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(Filters::class, 'apply'))->getParameters(),
+        );
+
+        expect($params)->toBe([
+            'query', 'filters', 'relatedTo', 'author',
+            'updatedAfter', 'updatedBefore', 'createdAfter', 'createdBefore', 'site',
+        ]);
+    });
+
+    it('types the first apply parameter as EntryQuery', function () {
+        $type = (new ReflectionMethod(Filters::class, 'apply'))->getParameters()[0]->getType();
+
+        expect((string) $type)->toBe(EntryQuery::class);
+    });
+
+    it('resolves natural keys through Keys and refuses unknown field handles', function () {
+        $source = (string) file_get_contents((new ReflectionClass(Filters::class))->getFileName());
+
+        expect($source)->toContain('idFor(')
+            ->and($source)->toContain('getFieldByHandle(')
+            ->and($source)->toContain('InvalidArgumentException');
+    });
+});

--- a/tests/Unit/Elements/Query/ProjectionTest.php
+++ b/tests/Unit/Elements/Query/ProjectionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\elements\query\Projection;
+use stimmt\craft\Mcp\elements\Reader;
+
+describe('Projection structure', function () {
+    it('exposes row(entry, fields, site)', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(Projection::class, 'row'))->getParameters(),
+        );
+
+        expect($params)->toBe(['entry', 'fields', 'site']);
+    });
+
+    it('knows the projectable attributes', function () {
+        $constant = (new ReflectionClass(Projection::class))->getConstant('ATTRIBUTES');
+
+        expect($constant)->toContain('slug')->toContain('status')
+            ->toContain('dateUpdated')->toContain('postDate')->toContain('url')
+            ->and($constant)->not->toContain('id');
+    });
+
+    it('rejects unknown names with the valid options listed', function () {
+        $source = (string) file_get_contents((new ReflectionClass(Projection::class))->getFileName());
+
+        expect($source)->toContain('InvalidArgumentException');
+    });
+});
+
+describe('Reader::readFields', function () {
+    it('exists with (element, handles, site) parameters', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(Reader::class, 'readFields'))->getParameters(),
+        );
+
+        expect($params)->toBe(['element', 'handles', 'site']);
+    });
+});

--- a/tests/Unit/Elements/Query/ProjectionTest.php
+++ b/tests/Unit/Elements/Query/ProjectionTest.php
@@ -28,6 +28,13 @@ describe('Projection structure', function () {
 
         expect($source)->toContain('InvalidArgumentException');
     });
+
+    it('sources attribute formulas from the shared Attributes class', function () {
+        $source = (string) file_get_contents((new ReflectionClass(Projection::class))->getFileName());
+
+        expect($source)->toContain('Attributes::value(')
+            ->and($source)->not->toContain("'Y-m-d H:i:s'");
+    });
 });
 
 describe('Reader::readFields', function () {

--- a/tests/Unit/Services/InstructionsTest.php
+++ b/tests/Unit/Services/InstructionsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\services\McpServerFactory;
+
+it('teaches the tool-selection ladder in the base instructions', function () {
+    $method = new ReflectionMethod(McpServerFactory::class, 'baseInstructions');
+    $instructions = $method->invoke(new McpServerFactory());
+
+    expect($instructions)->toContain('## Choosing Tools')
+        ->toContain('count_entries')
+        ->toContain('query_graphql')
+        ->toContain('get_database_schema')
+        ->toContain('information_schema')
+        ->toContain('last resort');
+});

--- a/tests/Unit/Tools/AnnotationsTest.php
+++ b/tests/Unit/Tools/AnnotationsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+
+// Every tool declares its blast radius: dangerous tools are marked
+// destructive, everything else is marked read-only and idempotent, so MCP
+// clients can gate and cache accordingly. reload_mcp mutates server state
+// without being dangerous, hence the single exemption.
+it('annotates every non-dangerous tool read-only and idempotent', function () {
+    $exempt = ['reload_mcp'];
+    $missing = [];
+
+    foreach (glob(__DIR__ . '/../../../src/tools/*.php') as $file) {
+        $class = 'stimmt\\craft\\Mcp\\tools\\' . basename($file, '.php');
+        foreach ((new ReflectionClass($class))->getMethods() as $method) {
+            $tools = $method->getAttributes(McpTool::class);
+            if ($tools === []) {
+                continue;
+            }
+
+            $tool = $tools[0]->newInstance();
+            $metas = $method->getAttributes(McpToolMeta::class);
+            $dangerous = $metas !== [] && $metas[0]->newInstance()->dangerous;
+
+            if ($dangerous || in_array($tool->name, $exempt, true)) {
+                continue;
+            }
+
+            if ($tool->annotations?->readOnlyHint !== true || $tool->annotations?->idempotentHint !== true) {
+                $missing[] = $tool->name;
+            }
+        }
+    }
+
+    expect($missing)->toBe([]);
+});

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -46,3 +46,35 @@ describe('EntryTools structure', function () {
             ->and($source)->not->toContain('newParentId');
     });
 });
+
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Schema\ToolAnnotations;
+
+describe('list_entries query surface', function () {
+    it('accepts the shared filter parameters', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(EntryTools::class, 'listEntries'))->getParameters(),
+        );
+
+        expect($params)->toContain('filters')->toContain('relatedTo')->toContain('author')
+            ->toContain('updatedAfter')->toContain('updatedBefore')
+            ->toContain('createdAfter')->toContain('createdBefore');
+    });
+
+    it('declares JSON schemas on the object parameters', function (string $param) {
+        $parameters = (new ReflectionMethod(EntryTools::class, 'listEntries'))->getParameters();
+        $byName = array_combine(array_map(fn ($p) => $p->getName(), $parameters), $parameters);
+
+        expect($byName[$param]->getAttributes(Schema::class))->toHaveCount(1);
+    })->with([['filters'], ['relatedTo']]);
+
+    it('is annotated read-only and idempotent', function () {
+        $tool = (new ReflectionMethod(EntryTools::class, 'listEntries'))
+            ->getAttributes(McpTool::class)[0]->newInstance();
+
+        expect($tool->annotations)->toBeInstanceOf(ToolAnnotations::class)
+            ->and($tool->annotations->readOnlyHint)->toBeTrue()
+            ->and($tool->annotations->idempotentHint)->toBeTrue();
+    });
+});

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -87,6 +87,9 @@ describe('list_entries query surface', function () {
         expect($schema->type)->toBe('array');
     });
 
+});
+
+describe('get_entry lookups', function () {
     it('resolves revision ids on id lookups', function () {
         $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
 

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -87,3 +87,16 @@ describe('list_entries query surface', function () {
         expect($schema->type)->toBe('array');
     });
 });
+
+describe('count_entries', function () {
+    it('is registered read-only with the shared filter parameters', function () {
+        $method = new ReflectionMethod(EntryTools::class, 'countEntries');
+        $tool = $method->getAttributes(McpTool::class)[0]->newInstance();
+        $params = array_map(fn (ReflectionParameter $p): string => $p->getName(), $method->getParameters());
+
+        expect($tool->name)->toBe('count_entries')
+            ->and($tool->annotations->readOnlyHint)->toBeTrue()
+            ->and($params)->toContain('groupBy')->toContain('filters')->toContain('relatedTo')
+            ->toContain('updatedAfter')->toContain('author');
+    });
+});

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -77,4 +77,13 @@ describe('list_entries query surface', function () {
             ->and($tool->annotations->readOnlyHint)->toBeTrue()
             ->and($tool->annotations->idempotentHint)->toBeTrue();
     });
+
+    it('accepts a fields projection parameter with an array schema', function () {
+        $parameters = (new ReflectionMethod(EntryTools::class, 'listEntries'))->getParameters();
+        $byName = array_combine(array_map(fn ($p) => $p->getName(), $parameters), $parameters);
+
+        $schema = $byName['fields']->getAttributes(Schema::class)[0]->newInstance();
+
+        expect($schema->type)->toBe('array');
+    });
 });

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+use Mcp\Schema\ToolAnnotations;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\tools\EntryTools;
 
@@ -46,9 +48,6 @@ describe('EntryTools structure', function () {
             ->and($source)->not->toContain('newParentId');
     });
 });
-
-use Mcp\Capability\Attribute\Schema;
-use Mcp\Schema\ToolAnnotations;
 
 describe('list_entries query surface', function () {
     it('accepts the shared filter parameters', function () {

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -108,4 +108,10 @@ describe('count_entries', function () {
             ->and($params)->toContain('groupBy')->toContain('filters')->toContain('relatedTo')
             ->toContain('updatedAfter')->toContain('author');
     });
+
+    it('normalizes the any status instead of aborting the query', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect(substr_count($source, "=== 'any' ? null"))->toBe(2);
+    });
 });

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -86,6 +86,12 @@ describe('list_entries query surface', function () {
 
         expect($schema->type)->toBe('array');
     });
+
+    it('resolves revision ids on id lookups', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain('revisions(null)');
+    });
 });
 
 describe('count_entries', function () {

--- a/tests/Unit/Tools/EntryWorkflowToolsTest.php
+++ b/tests/Unit/Tools/EntryWorkflowToolsTest.php
@@ -33,7 +33,6 @@ describe('EntryWorkflowTools structure', function () {
     });
 });
 
-
 describe('list_revisions', function () {
     it('is registered read-only with id, site, and pagination parameters', function () {
         $method = new ReflectionMethod(EntryWorkflowTools::class, 'listRevisions');

--- a/tests/Unit/Tools/EntryWorkflowToolsTest.php
+++ b/tests/Unit/Tools/EntryWorkflowToolsTest.php
@@ -32,3 +32,23 @@ describe('EntryWorkflowTools structure', function () {
             ->and($source)->toContain('nothing to publish');
     });
 });
+
+
+describe('list_revisions', function () {
+    it('is registered read-only with id, site, and pagination parameters', function () {
+        $method = new ReflectionMethod(EntryWorkflowTools::class, 'listRevisions');
+        $tool = $method->getAttributes(McpTool::class)[0]->newInstance();
+        $params = array_map(fn (ReflectionParameter $p): string => $p->getName(), $method->getParameters());
+
+        expect($tool->name)->toBe('list_revisions')
+            ->and($tool->annotations->readOnlyHint)->toBeTrue()
+            ->and($params)->toContain('id')->toContain('site')->toContain('limit')->toContain('offset');
+    });
+
+    it('summarizes revisions through the RevisionBehavior guard', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryWorkflowTools::class))->getFileName());
+
+        expect($source)->toContain('RevisionBehavior')
+            ->and($source)->toContain('revisionOf(');
+    });
+});

--- a/tests/Unit/Tools/GraphqlToolsTest.php
+++ b/tests/Unit/Tools/GraphqlToolsTest.php
@@ -96,7 +96,7 @@ describe('GraphqlTools dangerous tool', function () {
 });
 
 describe('GraphqlTools tool count', function () {
-    it('has exactly 4 public methods with McpTool attribute', function () {
+    it('has exactly 5 public methods with McpTool attribute', function () {
         $reflection = new ReflectionClass(GraphqlTools::class);
         $methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
 
@@ -104,6 +104,27 @@ describe('GraphqlTools tool count', function () {
             return !empty($method->getAttributes(McpTool::class));
         });
 
-        expect($toolMethods)->toHaveCount(4);
+        expect($toolMethods)->toHaveCount(5);
+    });
+});
+
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+
+describe('query_graphql', function () {
+    it('is registered read-only and not dangerous', function () {
+        $method = new ReflectionMethod(GraphqlTools::class, 'queryGraphql');
+        $tool = $method->getAttributes(McpTool::class)[0]->newInstance();
+        $meta = $method->getAttributes(McpToolMeta::class)[0]->newInstance();
+
+        expect($tool->name)->toBe('query_graphql')
+            ->and($tool->annotations->readOnlyHint)->toBeTrue()
+            ->and($meta->dangerous)->toBeFalse();
+    });
+
+    it('rejects non-query operations by parsing the document', function () {
+        $source = (string) file_get_contents((new ReflectionClass(GraphqlTools::class))->getFileName());
+
+        expect($source)->toContain('Parser::parse(')
+            ->and($source)->toContain('OperationDefinitionNode');
     });
 });

--- a/tests/Unit/Tools/GraphqlToolsTest.php
+++ b/tests/Unit/Tools/GraphqlToolsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Mcp\Capability\Attribute\McpTool;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\Mcp;
 use stimmt\craft\Mcp\tools\GraphqlTools;
 
@@ -107,8 +108,6 @@ describe('GraphqlTools tool count', function () {
         expect($toolMethods)->toHaveCount(5);
     });
 });
-
-use stimmt\craft\Mcp\attributes\McpToolMeta;
 
 describe('query_graphql', function () {
     it('is registered read-only and not dangerous', function () {

--- a/tests/Unit/Tools/GraphqlToolsTest.php
+++ b/tests/Unit/Tools/GraphqlToolsTest.php
@@ -128,3 +128,34 @@ describe('query_graphql', function () {
             ->and($source)->toContain('OperationDefinitionNode');
     });
 });
+
+// Behavioral coverage for the security mechanism itself: assertReadOnly only
+// touches the GraphQL parser (pure PHP, no Craft boot), so it can run here.
+describe('query_graphql read-only guard', function () {
+    $guard = function (string $query): void {
+        $tools = (new ReflectionClass(GraphqlTools::class))->newInstanceWithoutConstructor();
+        (new ReflectionMethod(GraphqlTools::class, 'assertReadOnly'))->invoke($tools, $query);
+    };
+
+    it('rejects mutations before execution', function () use ($guard) {
+        $guard('mutation { deleteEntry(id: 1) }');
+    })->throws(\Mcp\Exception\ToolCallException::class, 'execute_graphql');
+
+    it('rejects subscriptions before execution', function () use ($guard) {
+        $guard('subscription { entryUpdated { id } }');
+    })->throws(\Mcp\Exception\ToolCallException::class);
+
+    it('rejects syntax errors with the parser message', function () use ($guard) {
+        $guard('query {');
+    })->throws(\Mcp\Exception\ToolCallException::class, 'GraphQL syntax error');
+
+    it('allows named, anonymous, and fragment-bearing queries', function (string $query) use ($guard) {
+        $guard($query);
+
+        expect(true)->toBeTrue();
+    })->with([
+        ['query Entries { entries { id } }'],
+        ['{ entries { id } }'],
+        ['query Entries { entries { ...ids } } fragment ids on EntryInterface { id }'],
+    ]);
+});


### PR DESCRIPTION
Turns the read side of the entry tools from retrieval-only into a query surface, so a scoped read-only agent can answer anything a developer would otherwise answer with tinker or SQL.

## What changed

- **Filters on `list_entries`**: field-value filters (`:empty:`/`:notempty:`, natural keys for relation fields), `relatedTo`, `author`, and date-range params, all properly typed via the SDK's `#[Schema]` attribute. Handles that collide with real query params are refused instead of silently hijacking them.
- **`count_entries`**: totals and per-value breakdowns with the same filter set; groupBy an attribute, a date bucket (`month:dateUpdated` style), or a field handle (relations bucket by related title across all statuses; 200-bucket cap with a `truncated` flag). Counts include every status by default, documented against `list_entries`' live-only default.
- **`fields` projection on `list_entries`**: slim rows (id + title + requested attributes/fields) for scanning many entries cheaply. Attribute formulas are single-sourced in a shared `Attributes` class so full and projected payloads never drift.
- **`list_revisions`**: an entry's saved history (who, when, notes), deterministically ordered; `get_entry` now reads draft and revision element ids.
- **`query_graphql`**: read-only GraphQL; mutations and subscriptions are rejected at the AST level before execution, so it is not gated by `enableDangerousTools` and works on readonly HTTP scopes. `execute_graphql` is unchanged.
- **`status: "any"`** now means any status on both tools instead of Craft's silent zero-result abort.
- **Read-only + idempotent annotations** on every non-dangerous tool (`reload_mcp` exempt), locked in by an arch test.
- **Tool-selection ladder** in the server instructions, prompt guides, and the `tinker`/`run_query` descriptions, so agents reach for specific tools before escape hatches.
- Docs for all of the above; `composer analyse` now runs with `--memory-limit=512M` (the GraphQL AST surface exceeds the 128M default).

## How verified

- 334 unit tests (structural + pure-logic), PHPStan clean, Pint clean.
- Live integration against the playground over stdio: 24 checks green, including a created fixture proving disabled related elements are counted in `groupBy` buckets (the eager-load `['status' => null]` fix), the natural-key `relatedTo` positive case, bucket counts summing to totals, the `:empty:`/`:notempty:` partition invariant, revision reads via `get_entry`, and AST-level mutation/subscription/syntax rejection in `query_graphql`.