### PR TITLE
feat: content-scope tokens respect the linked user's CP permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Content-scope HTTP tokens now respect the linked user's real Craft permissions on entry writes (create, update, publish, delete, duplicate, copy to site), checked live per request through Craft's element authorization (#34)
+
 ## [1.4.0-beta.5] - 2026-07-14
 
 ### Added

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -79,7 +79,7 @@ Scope is applied on top of the plugin's existing global settings (`enabled`, `en
 
 Content-scope tokens now respect the linked Craft user's real permissions on entry writes. When a token with `content` scope creates, updates, publishes, deletes, duplicates, or copies an entry to another site, the write is checked against the token's user's actual permissions in the control panel through Craft's element authorization.
 
-This means that multi-site access, peer/draft visibility, and publishing permissions all behave exactly as they do in the control panel. If the user doesn't have permission to edit entries in a section on a given site, a write targeting that section on that site is refused. Revoking a user's control panel permissions takes effect immediately on the next request; there is no token rotation delay or grace period.
+This means that multi-site access, peer/draft visibility, and publishing permissions all behave exactly as they do in the control panel. If the user doesn't have permission to edit entries in a section on a given site, a write targeting that section on that site is refused. Revoking a user's control panel permissions takes effect immediately on the next request; there is no token rotation delay or grace period. Reads stay unrestricted on every scope; the permission check applies to entry writes only.
 
 If a write is refused, the error response carries a message like:
 

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -75,6 +75,20 @@ Each token carries a scope that limits which tools the connected client can see 
 
 Scope is applied on top of the plugin's existing global settings (`enabled`, `enableDangerousTools`, `disabledTools`): a tool disabled globally stays disabled over HTTP regardless of scope.
 
+### User permissions
+
+Content-scope tokens now respect the linked Craft user's real permissions on entry writes. When a token with `content` scope creates, updates, publishes, deletes, duplicates, or copies an entry to another site, the write is checked against the token's user's actual permissions in the control panel through Craft's element authorization.
+
+This means that multi-site access, peer/draft visibility, and publishing permissions all behave exactly as they do in the control panel. If the user doesn't have permission to edit entries in a section on a given site, a write targeting that section on that site is refused. Revoking a user's control panel permissions takes effect immediately on the next request; there is no token rotation delay or grace period.
+
+If a write is refused, the error response carries a message like:
+
+```
+This token's user 'editor' is not allowed to save this entry on site 'default' (Craft user permissions, checked live). Ask an admin to widen the user's permissions or mint a token for a user who has them.
+```
+
+Full-scope tokens are deliberately exempt from this check: they carry code execution capability, so they trust the token holder completely and skip Craft permission lookups. Readonly tokens are unaffected since they do not write. Scope remains the outer ceiling; a tool must be included in the token's scope to be callable at all, regardless of Craft permissions.
+
 ## Connecting Claude Desktop
 
 1. Open your Claude Desktop configuration file:
@@ -125,7 +139,7 @@ Revocation and expiry both take effect immediately on the next request; there is
 - **HTTPS only.** Bearer tokens are sent as plain headers; only use this transport behind TLS. Do not enable it on a plain HTTP site.
 - **Tokens are credentials.** Treat a minted token like a password: store it in a secrets manager or your MCP client's own config, never in a repository or shared document.
 - **Scope minimally.** Grant `readonly` or `content` by default and reserve `full` for developers who genuinely need code execution and direct database access.
-- **Scope, not Craft permissions, bounds a token.** Tools call Craft services directly, so a `content` token can write to any section regardless of what its user may edit in the control panel. The user link governs draft authorship and auditing; per-permission enforcement is a possible future addition.
+- **Scope is the outer ceiling; Craft permissions are the inner boundary.** A tool must be in the token's scope to be callable, but a `content` token's entry writes are also gated by the linked user's real Craft permissions. Full-scope tokens skip Craft permission checks (they carry code execution, so they trust the token holder completely). See [User permissions](#user-permissions) for details.
 - **IP allowlisting applies.** When the plugin's `allowedIps` setting is non-empty, the endpoint rejects requests from any other IP with a 403 before authentication runs. An empty list (the default) allows all IPs.
 - **Sessions are server-side files.** Each connection's session state is written under Craft's runtime storage path (`storage/runtime/mcp-sessions/`) and expires after `httpSessionTtl` seconds of inactivity (default: 3600). No session data is kept client-side beyond the `Mcp-Session-Id` header.
 

--- a/src/controllers/HttpController.php
+++ b/src/controllers/HttpController.php
@@ -116,6 +116,10 @@ class HttpController extends Controller {
         try {
             $psr7 = $server->run($transport);
         } finally {
+            // Defense in depth for persistent-worker SAPIs: enforcement must
+            // never leak from a content-scope request into the next one.
+            Authorization::reset();
+
             $stray = ob_get_clean();
             if (is_string($stray) && $stray !== '') {
                 $logger->warning('Stray output during MCP HTTP handling', ['output' => $stray]);

--- a/src/controllers/HttpController.php
+++ b/src/controllers/HttpController.php
@@ -11,10 +11,12 @@ use Mcp\Server\Session\FileSessionStore;
 use Psr\Log\LoggerInterface;
 use stimmt\craft\Mcp\http\Bridge;
 use stimmt\craft\Mcp\http\RecordStore;
+use stimmt\craft\Mcp\http\Scope;
 use stimmt\craft\Mcp\http\Token;
 use stimmt\craft\Mcp\http\Tokens;
 use stimmt\craft\Mcp\Mcp;
 use stimmt\craft\Mcp\services\McpServerFactory;
+use stimmt\craft\Mcp\support\Authorization;
 
 /**
  * The HTTP MCP endpoint. Bearer-token auth, per-user identity, then a
@@ -84,6 +86,10 @@ class HttpController extends Controller {
         }
 
         Craft::$app->getUser()->setIdentity($user);
+
+        if ($token->scope === Scope::Content) {
+            Authorization::enforceFor($user);
+        }
 
         return $token;
     }

--- a/src/elements/Writer.php
+++ b/src/elements/Writer.php
@@ -6,6 +6,7 @@ namespace stimmt\craft\Mcp\elements;
 
 use Craft;
 use craft\base\ElementInterface;
+use craft\elements\User;
 use craft\models\FieldLayout;
 use stimmt\craft\Mcp\elements\refs\Translator;
 
@@ -64,7 +65,12 @@ final readonly class Writer {
     }
 
     private function saveAsDraft(ElementInterface $element): bool {
-        Craft::$app->getDrafts()->saveElementAsDraft($element, null, null, null, false);
+        // Attribute the draft to the acting user (HTTP token identity), so
+        // Craft's own-draft permission logic applies to it; identityless
+        // runs (stdio console) keep a null creator as before.
+        $identity = Craft::$app->getUser()->getIdentity();
+        $creatorId = $identity instanceof User ? $identity->id : null;
+        Craft::$app->getDrafts()->saveElementAsDraft($element, $creatorId, null, null, false);
 
         return !$element->hasErrors();
     }

--- a/src/support/Authorization.php
+++ b/src/support/Authorization.php
@@ -9,6 +9,7 @@ use craft\base\ElementInterface;
 use craft\elements\User;
 use craft\services\Elements;
 use Mcp\Exception\ToolCallException;
+use Throwable;
 
 /**
  * Per-request acting-user authorization. Activated only for content-scope
@@ -87,7 +88,13 @@ final class Authorization {
             return;
         }
 
-        $site = $element->getSite()->handle;
+        // The refusal message must never be masked by a broken element
+        // (an unset siteId throws inside getSite()).
+        try {
+            $site = $element->getSite()->handle;
+        } catch (Throwable) {
+            $site = 'unknown';
+        }
         $noun = $element::lowerDisplayName();
 
         throw new ToolCallException(

--- a/src/support/Authorization.php
+++ b/src/support/Authorization.php
@@ -43,7 +43,11 @@ final class Authorization {
     }
 
     public static function assertCanPublish(ElementInterface $element): void {
-        self::assert($element, 'publish', fn ($elements) => $elements->canSaveCanonical($element, self::$user));
+        // Mirrors the control panel's apply-draft gate (ElementsController):
+        // the user must be allowed to save this element itself (for drafts:
+        // own draft or the peer-draft permission) AND its canonical version.
+        self::assert($element, 'publish', fn ($elements) => $elements->canSave($element, self::$user)
+            && $elements->canSaveCanonical($element, self::$user));
     }
 
     public static function assertCanDelete(ElementInterface $element): void {

--- a/src/support/Authorization.php
+++ b/src/support/Authorization.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\elements\User;
+use craft\services\Elements;
+use Mcp\Exception\ToolCallException;
+
+/**
+ * Per-request acting-user authorization. Activated only for content-scope
+ * HTTP tokens; everywhere else (stdio, readonly, full) every assertion is a
+ * no-op. Element checks run through Craft's element authorization (the same
+ * canSave/canDelete logic the control panel enforces) and work for ANY
+ * element type, so multi-site, peer, and draft nuances come from core, live
+ * per request. assertCan() covers raw permission strings for future
+ * non-element tools (schema, fields). Entry writes are the only consumers
+ * today; the seam is deliberately wider.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class Authorization {
+    private static ?User $user = null;
+
+    public static function enforceFor(User $user): void {
+        self::$user = $user;
+    }
+
+    public static function reset(): void {
+        self::$user = null;
+    }
+
+    public static function enforced(): bool {
+        return self::$user !== null;
+    }
+
+    public static function assertCanSave(ElementInterface $element): void {
+        self::assert($element, 'save', fn ($elements) => $elements->canSave($element, self::$user));
+    }
+
+    public static function assertCanPublish(ElementInterface $element): void {
+        self::assert($element, 'publish', fn ($elements) => $elements->canSaveCanonical($element, self::$user));
+    }
+
+    public static function assertCanDelete(ElementInterface $element): void {
+        self::assert($element, 'delete', fn ($elements) => $elements->canDelete($element, self::$user));
+    }
+
+    public static function assertCanDuplicate(ElementInterface $element): void {
+        self::assert($element, 'duplicate', fn ($elements) => $elements->canView($element, self::$user)
+            && $elements->canDuplicateAsDraft($element, self::$user));
+    }
+
+    public static function assertCanView(ElementInterface $element): void {
+        self::assert($element, 'view', fn ($elements) => $elements->canView($element, self::$user));
+    }
+
+    /**
+     * Raw permission gate for non-element operations (future schema and
+     * field tools). $action feeds the error message: "not allowed to
+     * {$action}".
+     */
+    public static function assertCan(string $permission, string $action): void {
+        if (self::$user === null || self::$user->can($permission)) {
+            return;
+        }
+
+        throw new ToolCallException(
+            "This token's user '" . self::$user->username . "' is not allowed to {$action}"
+            . " (missing Craft permission '{$permission}', checked live). Ask an admin to widen the"
+            . " user's permissions or mint a token for a user who has them.",
+        );
+    }
+
+    /**
+     * @param callable(Elements):bool $check
+     */
+    private static function assert(ElementInterface $element, string $action, callable $check): void {
+        if (self::$user === null) {
+            return;
+        }
+
+        if ($check(Craft::$app->getElements())) {
+            return;
+        }
+
+        $site = $element->getSite()->handle;
+        $noun = $element::lowerDisplayName();
+
+        throw new ToolCallException(
+            "This token's user '" . self::$user->username . "' is not allowed to {$action} this {$noun}"
+            . " on site '{$site}' (Craft user permissions, checked live). Ask an admin to widen the user's"
+            . ' permissions or mint a token for a user who has them.',
+        );
+    }
+}

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -24,6 +24,7 @@ use stimmt\craft\Mcp\elements\WriteMode;
 use stimmt\craft\Mcp\elements\Writer;
 use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\Mcp;
+use stimmt\craft\Mcp\support\Authorization;
 use stimmt\craft\Mcp\support\ElementModule;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
@@ -186,10 +187,18 @@ class EntryTools {
         ?RequestContext $context = null,
     ): array {
         return SafeExecution::run(function () use ($section, $type, $title, $slug, $site, $fields, $mode, $parent): array {
-            SiteResolver::resolve($site);
+            $siteModel = SiteResolver::resolve($site);
             $sectionModel = Craft::$app->getEntries()->getSectionByHandle($section)
                 ?? throw new ToolCallException("Section '{$section}' not found");
             $entryType = $this->entryType($sectionModel, $type);
+
+            // Authorization probe: an unsaved entry carrying the target
+            // section/type/site is exactly what Craft's canSave inspects.
+            Authorization::assertCanSave(new Entry([
+                'sectionId' => $sectionModel->id,
+                'typeId' => $entryType->id,
+                'siteId' => $siteModel?->id ?? Craft::$app->getSites()->getPrimarySite()->id, // @phpstan-ignore nullsafe.neverNull
+            ]));
 
             $attributes = [
                 'type' => Entry::class,
@@ -232,6 +241,7 @@ class EntryTools {
     ): array {
         return SafeExecution::run(function () use ($id, $site, $title, $slug, $status, $fields, $mode, $parent): array {
             $entry = $this->find($id, null, null, $site);
+            Authorization::assertCanSave($entry);
 
             $attributes = array_filter([
                 'title' => $title,

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -17,6 +17,7 @@ use stimmt\craft\Mcp\elements\Reader;
 use stimmt\craft\Mcp\elements\WriteMode;
 use stimmt\craft\Mcp\elements\Writer;
 use stimmt\craft\Mcp\enums\ToolCategory;
+use stimmt\craft\Mcp\support\Authorization;
 use stimmt\craft\Mcp\support\ElementModule;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
@@ -122,6 +123,7 @@ class EntryWorkflowTools {
     public function publishEntry(int $id, ?string $site = null, ?RequestContext $context = null): array {
         return SafeExecution::run(function () use ($id, $site): array {
             $entry = $this->find($id, $site, withDrafts: true);
+            Authorization::assertCanPublish($entry);
 
             if ($entry->getIsDraft()) {
                 return $this->applyDraft($entry, $site);
@@ -140,6 +142,7 @@ class EntryWorkflowTools {
     public function deleteEntry(int $id, ?string $site = null, ?RequestContext $context = null): array {
         return SafeExecution::run(function () use ($id, $site): array {
             $entry = $this->find($id, $site, withDrafts: true);
+            Authorization::assertCanDelete($entry);
 
             if (!Craft::$app->getElements()->deleteElement($entry)) {
                 throw new ToolCallException('Failed to delete entry');
@@ -165,6 +168,7 @@ class EntryWorkflowTools {
     ): array {
         return SafeExecution::run(function () use ($id, $site, $title, $slug, $fields): array {
             $entry = $this->find($id, $site);
+            Authorization::assertCanDuplicate($entry);
 
             $attributes = array_filter(['title' => $title, 'slug' => $slug], static fn (?string $v): bool => $v !== null);
             $duplicate = Craft::$app->getElements()->duplicateElement($entry, $attributes, asUnpublishedDraft: true);
@@ -199,6 +203,7 @@ class EntryWorkflowTools {
             $source = $this->find($id, $fromSite);
             $targetEntry = Entry::find()->id($id)->site($toSite)->status(null)->one()
                 ?? throw new ToolCallException("Entry {$id} does not exist on site '{$toSite}'; the section may not be enabled for it");
+            Authorization::assertCanSave($targetEntry);
 
             $payload = $this->reader->read($source, $fromSite);
             $result = $this->writer->update($targetEntry, [], $payload['fields'], WriteMode::Draft, $toSite);

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -281,6 +281,10 @@ class EntryWorkflowTools {
         }
 
         if ($drafts !== []) {
+            // The draft is the element being applied, so the permission check
+            // must run against it (peer-draft rules), not only the canonical.
+            Authorization::assertCanPublish($drafts[0]);
+
             return $this->applyDraft($drafts[0], $site);
         }
 

--- a/tests/Unit/Elements/WriterTest.php
+++ b/tests/Unit/Elements/WriterTest.php
@@ -46,3 +46,12 @@ describe('Writer', function () {
         expect($source)->toContain('draftElementId: $element->getIsDraft() ? $element->id : null');
     });
 });
+
+// Drafts must carry the acting user as creator, or Craft's own-draft
+// permission logic (publish without peer-draft rights) can never match.
+it('attributes drafts to the acting user', function () {
+    $source = (string) file_get_contents((new ReflectionClass(stimmt\craft\Mcp\elements\Writer::class))->getFileName());
+
+    expect($source)->toContain('instanceof User ? $identity->id : null')
+        ->and($source)->toContain('saveElementAsDraft($element, $creatorId');
+});

--- a/tests/Unit/Support/AuthorizationTest.php
+++ b/tests/Unit/Support/AuthorizationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\support\Authorization;
+
+describe('Authorization', function () {
+    afterEach(fn () => Authorization::reset());
+
+    it('is inactive by default and after reset', function () {
+        expect(Authorization::enforced())->toBeFalse();
+    });
+
+    it('exposes the four assertion seams for entry writes', function (string $method) {
+        expect(method_exists(Authorization::class, $method))->toBeTrue();
+    })->with([['assertCanSave'], ['assertCanPublish'], ['assertCanDelete'], ['assertCanDuplicate'], ['assertCanView'], ['assertCan']]);
+
+    it('short-circuits before Craft when not enforced', function () {
+        $source = (string) file_get_contents((new ReflectionClass(Authorization::class))->getFileName());
+
+        expect($source)->toContain('if (self::$user === null)')
+            ->and($source)->toContain('canSaveCanonical')
+            ->and($source)->toContain('canDuplicateAsDraft')
+            ->and($source)->toContain('ToolCallException');
+    });
+});

--- a/tests/Unit/Tools/AuthorizationWiringTest.php
+++ b/tests/Unit/Tools/AuthorizationWiringTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\tools\EntryTools;
+use stimmt\craft\Mcp\tools\EntryWorkflowTools;
+
+// Every entry-write tool must consult the acting-user guard before writing,
+// so content-scope HTTP tokens inherit the linked user's real CP permissions
+// (issue #34). Method => the assertion its body must contain.
+it('guards every entry-write tool with the acting-user authorization', function (string $class, string $method, string $assertion) {
+    $reflection = new ReflectionMethod($class, $method);
+    $file = (string) file_get_contents($reflection->getFileName());
+    $lines = array_slice(
+        explode("\n", $file),
+        $reflection->getStartLine() - 1,
+        $reflection->getEndLine() - $reflection->getStartLine() + 1,
+    );
+
+    expect(implode("\n", $lines))->toContain("Authorization::{$assertion}(");
+})->with([
+    [EntryTools::class, 'createEntry', 'assertCanSave'],
+    [EntryTools::class, 'updateEntry', 'assertCanSave'],
+    [EntryWorkflowTools::class, 'publishEntry', 'assertCanPublish'],
+    [EntryWorkflowTools::class, 'deleteEntry', 'assertCanDelete'],
+    [EntryWorkflowTools::class, 'duplicateEntry', 'assertCanDuplicate'],
+    [EntryWorkflowTools::class, 'copyEntryToSite', 'assertCanSave'],
+]);

--- a/tests/Unit/Tools/AuthorizationWiringTest.php
+++ b/tests/Unit/Tools/AuthorizationWiringTest.php
@@ -25,4 +25,7 @@ it('guards every entry-write tool with the acting-user authorization', function 
     [EntryWorkflowTools::class, 'deleteEntry', 'assertCanDelete'],
     [EntryWorkflowTools::class, 'duplicateEntry', 'assertCanDuplicate'],
     [EntryWorkflowTools::class, 'copyEntryToSite', 'assertCanSave'],
+    // The canonical-id publish path applies drafts[0]; the guard must check
+    // that draft object itself (peer-draft permissions), not only the canonical.
+    [EntryWorkflowTools::class, 'publishCanonical', 'assertCanPublish'],
 ]);


### PR DESCRIPTION
Closes #34.

A content-scope HTTP token minted for an editor now inherits that editor's real Craft permissions on entry writes, checked live on every request. A token for a user who can only edit one section can only write to that section, exactly like their CP login.

## What changed

- **New `support\Authorization` guard**: a per-request acting-user gate, activated only when a content-scope HTTP token authenticates. All checks go through Craft's own element authorization (`Elements::canSave`/`canSaveCanonical`/`canDelete`/`canView`/`canDuplicateAsDraft`), so multi-site, peer, and draft nuances behave exactly like the control panel rather than a parallel permission implementation. The class is deliberately element-generic plus a raw `assertCan(permission, action)` seam, so future asset/category/schema tools reuse it unchanged.
- **All six entry-write tools guarded** (create, update, publish, delete, duplicate, copy to site), locked in by an arch test that fails if a write tool ever drops its guard. Publishing mirrors the CP's apply-draft gate: the acting user must be allowed to save the draft itself (own draft or peer-draft permission) AND its canonical; the canonical-id publish route checks the actual draft being applied.
- **Drafts are now attributed to the acting user** (`Writer` passes the identity as draft creator), so an editor can publish their own drafts without needing peer-draft permissions; identityless stdio runs keep a null creator as before.
- **Boundaries**: stdio is untouched (no token identity, developer transport). `readonly` has no writes. `full` is deliberately exempt (trusted developer tier with code execution anyway). Reads stay unrestricted on every scope. Token scope remains the outer ceiling. Refusals are loud, worded errors naming the user, action, element, site, and remediation; revoking CP permissions takes effect on the next request, no token rotation.
- Defense in depth: enforcement resets per request in the controller's `finally`, so persistent-worker SAPIs can never leak enforcement across requests.
- Docs: new "User permissions" section in the HTTP transport guide.

## How verified

- 351 unit tests (structural + arch), PHPStan clean, Pint clean.
- Live against a real Craft 5 install over HTTP, 42 checks green across two rounds: a one-section editor's token creates drafts in its section but is refused (create/update/publish/delete) everywhere else with the worded errors; reads work across sections; an admin content token is unaffected; stdio writes stay unguarded; own-draft publish succeeds WITHOUT peer-draft permissions; a colleague's draft is refused via both the draft-id and canonical-id publish routes; all fixtures (users, groups, tokens, entries) verifiably cleaned up afterwards.