### PR TITLE
fix: serve the HTTP endpoint on control-panel-on-root installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The HTTP endpoint now works on installs that serve the control panel from the root of its domain (`cpTrigger` null): the endpoint registers as a CP URL rule there, since such hosts never consult site URL rules. Craft intercepts the default `mcp` path for guests on those hosts (it matches the plugin handle, a Craft core behavior that runs before routing), so a different `httpPath` (for example `mcp-http`) is required and the new "Control panel on the root domain" section in the HTTP transport guide explains the setup.
+
 ## [1.4.0-beta.7] - 2026-07-17
 
 ### Added

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -202,6 +202,18 @@ Sessions are stored in the `mcp_sessions` table, so they are shared across every
 
 If you need a different backend (for example Redis), set `httpSessionStore` in `config/mcp.php` to a class name implementing `Mcp\Server\Session\SessionStoreInterface`, or a callable that returns one. See [Configuration](configuration.md) for details. Tracked in issue [#41](https://github.com/stimmtdigital/craft-mcp/issues/41).
 
+## Control panel on the root domain
+
+Some installs serve the control panel from the root of its own domain (`cpTrigger` set to `null` plus a `baseCpUrl` such as `https://cms.example.com`). On such a host every request counts as a control panel request, and the plugin registers the endpoint as a CP URL rule so it stays reachable.
+
+One Craft behavior cannot be worked around: for guests, Craft intercepts any CP request whose first URL segment matches a plugin handle before routing runs, and the default `httpPath` (`mcp`) is exactly this plugin's handle. With the control panel on the root domain you must therefore pick a different path in `config/mcp.php`, and avoid paths that shadow real control panel routes (`entries`, `settings`, and so on):
+
+```php
+'httpPath' => 'mcp-http',
+```
+
+The token reveal and the console command build their endpoint URL from `httpPublicUrl` (or the primary site URL) plus `httpPath`, so once the path is configured the printed URL is correct. On plugin versions without CP rule support, `https://cms.example.com/index.php?action=mcp/http/handle` reaches the endpoint as an action request and works with the same bearer token.
+
 ## Troubleshooting
 
 ### 401 Unauthorized

--- a/src/Mcp.php
+++ b/src/Mcp.php
@@ -209,7 +209,7 @@ class Mcp extends BasePlugin {
      */
     private function registerHttpEndpoint(): void {
         $request = Craft::$app->getRequest();
-        if (!$request instanceof WebRequest || !$request->getIsSiteRequest()) {
+        if (!$request instanceof WebRequest) {
             return;
         }
 
@@ -221,6 +221,38 @@ class Mcp extends BasePlugin {
         Event::on(
             UrlManager::class,
             UrlManager::EVENT_REGISTER_SITE_URL_RULES,
+            static function (RegisterUrlRulesEvent $event) use ($settings): void {
+                $event->rules[$settings->httpPath] = 'mcp/http/handle';
+            },
+        );
+
+        $this->registerCpEndpointRule($settings);
+    }
+
+    /**
+     * With the control panel on the root of its domain (empty cpTrigger),
+     * every request on that host is a CP request and site URL rules are
+     * never consulted, so the endpoint must exist as a CP rule too. Craft
+     * additionally intercepts guest CP requests whose first segment matches
+     * a plugin handle (plugin template routing) BEFORE any URL rule runs,
+     * so the default path, which equals this plugin's handle, cannot be
+     * served on such hosts; the site owner must pick another httpPath.
+     */
+    private function registerCpEndpointRule(Settings $settings): void {
+        $trigger = Craft::$app->getConfig()->getGeneral()->cpTrigger;
+        if ($trigger !== null && $trigger !== '') {
+            return;
+        }
+
+        if ($settings->httpPath === $this->id) {
+            Craft::warning(sprintf('httpPath "%s" matches the plugin handle; with the control panel on the root domain, Craft intercepts that path for guests before routing. Set httpPath to a different value (for example "mcp-http") to serve the MCP endpoint on this host.', $settings->httpPath), __METHOD__);
+
+            return;
+        }
+
+        Event::on(
+            UrlManager::class,
+            UrlManager::EVENT_REGISTER_CP_URL_RULES,
             static function (RegisterUrlRulesEvent $event) use ($settings): void {
                 $event->rules[$settings->httpPath] = 'mcp/http/handle';
             },

--- a/tests/Unit/Web/HttpEndpointTest.php
+++ b/tests/Unit/Web/HttpEndpointTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\Mcp;
+
+// Craft is never booted in these tests: registering the endpoint wires
+// yii\base\Event handlers against the UrlManager and reads live request
+// state, so the assertions are structural. They pin the routing contract
+// that makes the endpoint reachable on control-panel-on-root installs
+// (empty cpTrigger): both rule sets registered, no site-request gate, and
+// the plugin-handle collision guarded instead of silently broken.
+describe('HTTP endpoint registration', function () {
+    $source = static function (string $method): string {
+        $reflection = new ReflectionMethod(Mcp::class, $method);
+        $file = file($reflection->getFileName());
+
+        return implode('', array_slice($file, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1));
+    };
+
+    it('registers the endpoint without a site-request gate', function () use ($source) {
+        $body = $source('registerHttpEndpoint');
+
+        expect($body)->toContain('EVENT_REGISTER_SITE_URL_RULES')
+            ->and($body)->toContain('registerCpEndpointRule')
+            ->and($body)->not->toContain('getIsSiteRequest');
+    });
+
+    it('registers a CP url rule for control-panel-on-root installs', function () use ($source) {
+        $body = $source('registerCpEndpointRule');
+
+        expect($body)->toContain('EVENT_REGISTER_CP_URL_RULES')
+            ->and($body)->toContain('cpTrigger');
+    });
+
+    it('refuses the CP rule when httpPath collides with the plugin handle', function () use ($source) {
+        $body = $source('registerCpEndpointRule');
+
+        expect($body)->toContain('$settings->httpPath === $this->id')
+            ->and($body)->toContain('Craft::warning');
+    });
+});


### PR DESCRIPTION
On installs that serve the control panel from the root of its own domain (`cpTrigger` set to `null` plus a `baseCpUrl`), the HTTP transport endpoint was unreachable: every request on that host counts as a CP request, and the endpoint existed only as a site URL rule behind a site-request-only registration gate. Guests hitting the default `/mcp` path got a 403 "Login Required" instead, because Craft intercepts guest CP requests whose first URL segment matches a plugin handle (plugin template routing) before URL rules run, and the default `httpPath` equals this plugin's handle.

## What changed

- `registerHttpEndpoint()` no longer requires a site request; the site URL rule registers as before, and when `cpTrigger` is empty a CP URL rule for the same path registers too, so CP-on-root hosts route the endpoint normally.
- The plugin-handle collision cannot be fixed plugin-side (Craft core intercepts before routing), so when `cpTrigger` is empty and `httpPath` still equals the plugin handle, the CP rule is skipped and a warning is logged telling the owner to pick a different path (for example `mcp-http`).
- New "Control panel on the root domain" section in the HTTP transport guide covering the required `httpPath` change, the CP-route-shadowing caveat, and the `index.php?action=mcp/http/handle` action-URL fallback that works on older plugin versions.

## How verified

- Reproduced the 403 byte-for-byte on a CP-on-root install, then confirmed the fix live on the same setup: unauthenticated POST answers the bearer challenge, authenticated `initialize` completes a full 200 handshake, and the CP itself keeps working on the root.
- Confirmed the collision is core Craft behavior by trace: `craft\web\Application::handleRequest()` calls `loginRequired()` for guest CP requests whose first segment resolves through `Plugins::getPlugin()`, before any URL rule is consulted.
- Three structural tests pin the routing contract (no site-request gate, CP rule registration keyed on `cpTrigger`, collision guard). Full gate green: 479 tests, PHPStan and Pint clean.
