### PR TITLE
build: update mcp/sdk to ^0.7 and rector to 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgraded `mcp/sdk` from `^0.6` to `^0.7`. Scope-based tool filtering keeps working under the SDK's new deferred element loading, since a registry supplied via `setRegistry()` is loaded eagerly at build time; a test pins that contract so a future SDK change that breaks it fails loudly.
+- Upgraded `rector/rector` from `2.5.5` to `2.5.7`.
+
 ## [1.4.0-beta.8] - 2026-07-20
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.3",
         "craftcms/cms": "^5.0",
-        "mcp/sdk": "^0.6",
+        "mcp/sdk": "^0.7",
         "psr/event-dispatcher": "^1.0",
         "psr/simple-cache": "^2.0 || ^3.0",
         "psy/psysh": "^0.12",
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18",
-        "rector/rector": "2.5.5",
+        "rector/rector": "2.5.7",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "phpstan/phpstan": "^2.0",

--- a/tests/Unit/Services/McpServerFactoryEventDispatcherTest.php
+++ b/tests/Unit/Services/McpServerFactoryEventDispatcherTest.php
@@ -90,3 +90,73 @@ function initializeCapabilities(Server $server): Mcp\Schema\ServerCapabilities {
 
     throw new RuntimeException('InitializeHandler not found among the built Protocol request handlers.');
 }
+
+/**
+ * mcp/sdk 0.7 defers loader-based element loading to the first registry
+ * read, and Registry::unregisterTool() silently no-ops for elements that
+ * are not loaded yet. McpServerFactory::filterTools() unregisters scoped
+ * and privileged tools right after Builder::build(), so it depends on the
+ * SDK's documented exception: a registry supplied via setRegistry() is
+ * loaded eagerly at build time. These tests pin that contract; if a future
+ * SDK release breaks it, scope filtering would silently stop working and
+ * this suite must fail loudly.
+ */
+describe('eager loading of a custom registry (SDK 0.7 contract)', function () {
+    $tool = static fn (string $name): Mcp\Schema\Tool => new Mcp\Schema\Tool(
+        name: $name,
+        title: null,
+        inputSchema: ['type' => 'object'],
+        description: null,
+        annotations: null,
+    );
+
+    it('loads a setRegistry() registry eagerly at build time', function () use ($tool) {
+        $registry = new Registry(null);
+        $loader = new class ($tool('loaded-tool')) implements Mcp\Capability\Registry\Loader\LoaderInterface {
+            public function __construct(private readonly Mcp\Schema\Tool $tool) {
+            }
+
+            public function load(Mcp\Capability\RegistryInterface $registry): void {
+                $registry->registerTool($this->tool, static fn (): string => 'ok');
+            }
+        };
+
+        Server::builder()
+            ->setServerInfo(name: 'test', version: '1.0.0')
+            ->setRegistry($registry)
+            ->addLoader($loader)
+            ->build();
+
+        expect($registry->hasTools())->toBeTrue();
+    });
+
+    it('keeps post-build unregistration effective across later reads', function () use ($tool) {
+        $registry = new Registry(null);
+        $loader = new class ($tool('privileged-tool'), $tool('plain-tool')) implements Mcp\Capability\Registry\Loader\LoaderInterface {
+            /** @var list<Mcp\Schema\Tool> */
+            private readonly array $tools;
+
+            public function __construct(Mcp\Schema\Tool ...$tools) {
+                $this->tools = array_values($tools);
+            }
+
+            public function load(Mcp\Capability\RegistryInterface $registry): void {
+                foreach ($this->tools as $tool) {
+                    $registry->registerTool($tool, static fn (): string => 'ok');
+                }
+            }
+        };
+
+        Server::builder()
+            ->setServerInfo(name: 'test', version: '1.0.0')
+            ->setRegistry($registry)
+            ->addLoader($loader)
+            ->build();
+
+        $registry->unregisterTool('privileged-tool');
+        $names = array_map(static fn ($t) => $t->name, $registry->getTools()->references);
+
+        expect($names)->toContain('plain-tool')
+            ->and($names)->not->toContain('privileged-tool');
+    });
+});


### PR DESCRIPTION
Supersedes the two Dependabot PRs (#44 mcp/sdk, #45 rector) with the compatibility work they each need folded in, so they can be closed in favor of this.

## What changed

- `mcp/sdk` `^0.6` to `^0.7`.
- `rector/rector` `2.5.5` to `2.5.7`.

## The one thing worth reviewing (mcp/sdk 0.7)

0.7 defers loader-based element loading to the first registry read, and `Registry::unregisterTool()` silently no-ops for elements not yet loaded. `McpServerFactory::filterTools()` unregisters out-of-scope and privileged tools right after `build()`, so on paper that ordering could have started serving the full unfiltered tool set to scoped tokens.

It does not, because the SDK eagerly loads a registry supplied via `setRegistry()` at build time (`Builder::build()`, guarded by `hasCustomRegistry`), which is exactly how the factory wires it. Filtering therefore runs against a fully loaded registry, unchanged from 0.6.

Verified rather than assumed:
- Two new tests in `McpServerFactoryEventDispatcherTest.php` pin the contract: a `setRegistry()` registry is loaded eagerly at build, and a tool unregistered after `build()` stays absent across later registry reads. If a future SDK release breaks the eager-load guarantee, these fail loudly.
- Live over the HTTP transport on the SDK 0.7 build: a content-scope token returns 54 tools on a single page, with the dangerous tools (`tinker`, `run_query`, and the rest) correctly stripped. Privileged install-introspection tools remain only because the test token was linked to an admin user, which is the documented behavior, not a leak.

## How verified

Full gate green (481 tests, PHPStan and Pint clean) plus the live HTTP check above.
