### PR TITLE
feat: create, position, and move Matrix blocks by their own id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `create_nested_entry` creates a block inside a Matrix field, targeted by owner id, field handle, and entry type. A nested entry has no section of its own, so `create_entry` could not address one, and adding the first block of a type left no option but resending the owner's whole field value. An optional `position` places the block instead of appending it.
+- `move_nested_entry` moves a block to a position within its field without resending the owner's field value. Positions are 1-based and clamp to last, and the response reports the position actually taken. Order belongs to the owner rather than to the block, so a drafted reorder is a draft of the owner and `publish_entry` applies it, like any other draft-first write.
+
+### Fixed
+- Editing a single Matrix block no longer moves it to the end of its field. Applying a draft of a lone nested element cannot recover the previous `sortOrder` and falls through to `max+1`, and rows left behind by trashed blocks inflate that maximum further, so a block edited through its own id silently jumped past its siblings. The position is now read before the draft is applied and restored afterwards.
+
 ## [1.4.0-beta.9] - 2026-07-20
 
 ### Changed

--- a/docs/content-writing.md
+++ b/docs/content-writing.md
@@ -52,7 +52,9 @@ That id works directly with the entry tools, same as any other entry id:
 
 This is the safer default for a single-block change. Sending the owner's Matrix field through `update_entry` replaces the field's entire value; any block left out of the payload is deleted. Targeting a block's own id skips that risk entirely, since the owner's field value and every sibling block are never touched.
 
-One limit: this only reaches a block whose type already appears somewhere in the field. Adding the first-ever block of a brand new type still needs the full owner-field payload.
+Adding a block works the same way, through `create_nested_entry owner=<ownerId> field=<matrixFieldHandle> type=<entryTypeHandle>`. It creates the block against the owner's field directly. `publish_entry` then attaches it, appended after the existing blocks, or at `position` when one is given.
+
+Reordering is `move_nested_entry id=<blockId> position=<n>`, which also leaves sibling content untouched. Order belongs to the owner rather than to the block, so a drafted reorder lands on a draft of the owner: the response carries that draft's id, the live page keeps its order, and `publish_entry` applies it like any other write.
 
 ## Discover the Shape First: describe_entry_schema
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -33,6 +33,8 @@ These tools let AI assistants work with your Craft content:
 | `count_entries` | Count entries with the same filters as `list_entries`; optional `groupBy` for per-attribute, per-date-bucket, or per-field-value breakdowns |
 | `get_entry` | Get one entry by id or slug, in the payload format that `create_entry`/`update_entry` accept as `fields` |
 | `create_entry` | Create an entry from payload-format `fields`; saves as a draft by default |
+| `create_nested_entry` | Create a block in a Matrix field, targeted by owner id, field handle, and entry type, without resending the owner's field value |
+| `move_nested_entry` | Move a block to a position within its Matrix field, without resending the owner's field value |
 | `update_entry` | Update an entry by id from payload-format `fields`; drafts on top of a live entry by default |
 | `list_drafts` | List pending drafts awaiting review, newest first, with publish ids and control panel links |
 | `list_revisions` | List an entry's saved revisions, newest first: who saved each one, when, and with what notes |
@@ -164,6 +166,8 @@ Some tools can modify data or execute code, which may not be appropriate in all 
 | `execute_graphql` | High | Executes GraphQL queries/mutations that can modify data |
 | `run_query` | Medium | Executes SQL queries (limited to SELECT, but still exposes data) |
 | `create_entry` | Medium | Creates new entries in your content |
+| `create_nested_entry` | Medium | Creates new blocks inside an entry's Matrix field |
+| `move_nested_entry` | Medium | Reorders blocks inside an entry's Matrix field |
 | `update_entry` | Medium | Modifies existing entry content and fields |
 | `publish_entry` | Medium | Applies a draft to its canonical entry, or enables a disabled entry |
 | `delete_entry` | Medium | Moves an entry to the trash |

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -279,6 +279,107 @@ create_entry section="pages" type="page" title="Team" parent="about"
 
 ---
 
+### create_nested_entry
+
+Create a block inside a Matrix field on an owner entry. A nested entry has no section of its own, so `create_entry` cannot address one; this tool targets the block by owner entry id, Matrix field handle, and block entry-type handle instead. Saves as a draft unless `mode` or the `entryWriteMode` setting says `live`; `publish_entry` then attaches it, appended after the existing blocks.
+
+Prefer this over rebuilding the owner's whole field value with `update_entry`: that payload has to carry every sibling block, and any block left out is removed. 
+
+> **Note:** This is a dangerous tool that can be disabled via configuration.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `owner` | int | Yes | Id of the entry that owns the Matrix field |
+| `field` | string | Yes | Matrix field handle on the owner's field layout |
+| `type` | string | Yes | Entry type handle for the new block, which the field must allow |
+| `title` | string | No | Block title, for block types that have a title field |
+| `site` | string | No | Site to create the block on (defaults to the owner's site) |
+| `fields` | string | No | JSON string in the payload format, containing the block's field values |
+| `mode` | string | No | `"draft"` or `"live"`, overriding the `entryWriteMode` setting for this call |
+| `position` | int | No | 1-based position within the field; appends when omitted, and clamps to last when past the end |
+
+**Examples:**
+
+```
+# Add a block, then attach it
+create_nested_entry owner=231592 field="cards" type="textCard"
+publish_entry id=231719
+
+# Add a block with field values in one call
+create_nested_entry owner=231592 field="cards" type="textCard" fields='{"heading": "Our approach"}'
+
+# Insert as the second block rather than appending
+create_nested_entry owner=231592 field="cards" type="textCard" position=2
+
+# Attach immediately, skipping the draft step
+create_nested_entry owner=231592 field="cards" type="mediaCard" mode="live"
+```
+
+**Response:**
+
+Same shape as `create_entry`. `elementId` is the block's own id, which `get_entry`, `update_entry`, and `delete_entry` all accept directly.
+
+Authorization is checked against the owner entry, since the block is written into the owner's content. Unknown handles are rejected with the valid options listed: a wrong `field` reports the owner's Matrix field handles, and a wrong `type` reports the entry types that field allows.
+
+---
+
+### move_nested_entry
+
+Move a block to a different position within its Matrix field, without resending the owner's field value.
+
+Positions are 1-based, and anything past the end lands last, so "make this the final block" does not require counting the field first. The response reports the position actually taken.
+
+Order belongs to the owner rather than to the block: each owner keeps its own record of where its blocks sit, and a draft of an entry carries its own copy. So a drafted reorder is a draft *of the owner*. The live entry keeps its order until `publish_entry` applies it, exactly like any other draft-first write.
+
+> **Note:** This is a dangerous tool that can be disabled via configuration.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | int | Yes | The block's own entry id |
+| `position` | int | Yes | 1-based target position within the field; clamped to last when past the end |
+| `site` | string | No | Site to resolve the block on |
+| `mode` | string | No | `"draft"` or `"live"`, overriding the `entryWriteMode` setting for this call |
+
+**Examples:**
+
+```
+# Make a block the first in its field, then apply it
+move_nested_entry id=231596 position=1
+publish_entry id=231767
+
+# Send a block to the end
+move_nested_entry id=231594 position=999
+
+# Reorder the live entry immediately, skipping the draft step
+move_nested_entry id=231596 position=1 mode="live"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "moved": 231596,
+  "owner": 231592,
+  "position": 1,
+  "state": "draft",
+  "draftElementId": 231767,
+  "cpEditUrl": "https://example.com/admin/content/entries/pages/231592-about?draftId=23838"
+}
+```
+
+`draftElementId` is the owner's draft, which is what `publish_entry` takes; it is `null` and `state` is `"live"` when the reorder went straight to the canonical entry.
+
+Authorization is checked against the owner, as with `create_nested_entry`, because reordering changes the owner's content rather than the block's own values. Passing an entry that is not a block returns an error naming the id.
+
+Reordering renumbers the field's live blocks contiguously. Blocks in the trash keep their ownership records, so a field that has had blocks deleted may start with gaps; a move closes them.
+
+---
+
 ### update_entry
 
 Update an entry by id. In draft mode (the default) a live entry gets a draft on top rather than being changed directly; `publish_entry` applies it. `fields` is payload-format JSON; only the values you supply change.

--- a/src/services/McpServerFactory.php
+++ b/src/services/McpServerFactory.php
@@ -194,9 +194,10 @@ This MCP server provides access to a Craft CMS installation.
 1. Call `describe_entry_schema` for the section first; pass `example` (an entry id or slug) to get a real entry as a golden fixture. Every field carries an `input` shape describing the exact payload it accepts.
 2. The payload format is symmetric: what `get_entry` returns is exactly what `create_entry`/`update_entry` accept. Read one, tweak it, write it back.
 3. Use natural keys, never numeric ids: relations are `{"section": "...", "slug": "..."}`, assets `{"volume": "...", "filename": "..."}`, categories/tags `{"group": "...", "slug": "..."}`, users `{"username": "..."}`. Matrix blocks are keyed objects (`new1`, `new2`, ...) with the entry-type handle as `type`.
-4. Writes land as DRAFTS by default: the response carries `draftElementId` and a `cpEditUrl` deep link for human review; `publish_entry` makes them live. Nothing touches live content until published.
-5. Always read the `warnings` list on write responses: unresolvable natural keys become warnings, never guesses or silent drops. Validation failures return per-field errors.
-6. Multi-site installs: pass the `site` handle parameter; `copy_entry_to_site` moves content between sites.
+4. Matrix blocks are entries, so target one directly instead of resending the owner's field, which deletes any block left out: `update_entry` on a block id edits it, `create_nested_entry` adds one, `move_nested_entry` reorders, `delete_entry` removes one. Siblings stay untouched.
+5. Writes land as DRAFTS by default: the response carries `draftElementId` and a `cpEditUrl` deep link for human review; `publish_entry` makes them live. Nothing touches live content until published.
+6. Always read the `warnings` list on write responses: unresolvable natural keys become warnings, never guesses or silent drops. Validation failures return per-field errors.
+7. Multi-site installs: pass the `site` handle parameter; `copy_entry_to_site` moves content between sites.
 
 The full contract lives in the `craft://guides/content-writing` resource.
 

--- a/src/support/NestedOrder.php
+++ b/src/support/NestedOrder.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\base\NestedElementInterface;
+use craft\db\Query;
+use craft\db\Table;
+use craft\elements\Entry;
+use craft\helpers\Db;
+use Throwable;
+use yii\base\InvalidConfigException;
+
+/**
+ * Position of a nested element within its owner's field.
+ *
+ * Ordering lives in elements_owners.sortOrder, held per owner rather than in
+ * the element's own content, which is why a draft of the owner carries its own
+ * copy. Craft's own control panel never hits the problem below: it drafts the
+ * owner and rewrites the whole field on publish. Applying a draft of a lone
+ * nested element takes a different path, where Craft's ownership save cannot
+ * recover the previous sortOrder and falls through to max+1, silently moving
+ * the element to the end of its field.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class NestedOrder {
+    /**
+     * Current sortOrder of the element a draft will be applied to, or null
+     * when the element is not nested and ordering does not apply.
+     */
+    public static function capture(ElementInterface $element): ?int {
+        if (!$element instanceof NestedElementInterface) {
+            return null;
+        }
+
+        $ownerId = $element->getOwnerId();
+        if ($ownerId === null) {
+            return null;
+        }
+
+        // An unpublished draft is its own canonical, so this reads the row the
+        // draft already holds; an edit draft reads the row of the element it
+        // will be applied to.
+        return self::sortOrderOf((int) $element->getCanonicalId(), $ownerId);
+    }
+
+    /**
+     * Put a just-applied element back where it was, if applying moved it.
+     */
+    public static function restore(ElementInterface $element, ?int $sortOrder): void {
+        if ($sortOrder === null || !$element instanceof NestedElementInterface) {
+            return;
+        }
+
+        $ownerId = $element->getOwnerId();
+        if ($ownerId === null || self::sortOrderOf((int) $element->id, $ownerId) === $sortOrder) {
+            return;
+        }
+
+        Db::update(Table::ELEMENTS_OWNERS, ['sortOrder' => $sortOrder], [
+            'elementId' => $element->id,
+            'ownerId' => $ownerId,
+        ]);
+
+        self::invalidate($element, $ownerId);
+    }
+
+    /**
+     * Move a nested element to a 1-based position among its live siblings,
+     * renumbering the field contiguously. Positions past the end land last.
+     *
+     * Ordering is stored per owner, so passing $ownerId reorders one owner's
+     * view of the field -- a draft of the owner carries its own rows, which is
+     * what lets a reorder be drafted and applied like any other write.
+     *
+     * @return int the position actually taken
+     */
+    public static function place(NestedElementInterface $element, int $position, ?int $ownerId = null): int {
+        $ownerId ??= $element->getOwnerId();
+
+        // getField() resolves the owner's layout, so an orphaned or
+        // misconfigured nested element throws rather than returning null.
+        // Craft only started catching that internally in recent 5.x, so guard
+        // it here instead of relying on the running version to be forgiving.
+        try {
+            $fieldId = $element->getField()?->id;
+        } catch (InvalidConfigException) {
+            return $position;
+        }
+
+        if ($ownerId === null || $fieldId === null) {
+            return $position;
+        }
+
+        $siblings = self::siblingIds($ownerId, $fieldId);
+        $id = (int) $element->id;
+
+        // Renumbering from the live siblings alone also drops the gaps left by
+        // trashed blocks, whose elements_owners rows survive a soft delete and
+        // otherwise inflate every later max+1.
+        $ordered = array_values(array_filter($siblings, static fn (int $sibling): bool => $sibling !== $id));
+        $index = max(0, min($position - 1, count($ordered)));
+        array_splice($ordered, $index, 0, [$id]);
+
+        foreach ($ordered as $offset => $siblingId) {
+            Db::update(Table::ELEMENTS_OWNERS, ['sortOrder' => $offset + 1], [
+                'elementId' => $siblingId,
+                'ownerId' => $ownerId,
+            ]);
+        }
+
+        self::invalidate($element, $ownerId);
+
+        return $index + 1;
+    }
+
+    /**
+     * Invalidate for the block and its owner, because neither call covers the
+     * other. Craft derives its tags from whichever element it is handed: the
+     * block contributes its own id plus the container field, the owner
+     * contributes its section. A reorder changes the field's composition and
+     * what the owner renders, so both sets matter, and over-invalidating costs
+     * a cache miss where under-invalidating serves a stale page.
+     *
+     * Invalidating a nested element also walks to its owner, which throws on
+     * an orphan. The rows are already written by this point, so a failure here
+     * must not turn a successful reorder into a reported error.
+     */
+    private static function invalidate(ElementInterface $element, ?int $ownerId): void {
+        $owner = $ownerId === null
+            ? null
+            : Entry::find()->id($ownerId)->drafts(null)->status(null)->one();
+
+        foreach ([$element, $owner] as $target) {
+            if (!$target instanceof ElementInterface) {
+                continue;
+            }
+
+            try {
+                Craft::$app->getElements()->invalidateCachesForElement($target);
+            } catch (Throwable) {
+                // Stale caches are recoverable; a thrown reorder is not.
+            }
+        }
+    }
+
+    private static function sortOrderOf(int $elementId, int $ownerId): ?int {
+        $sortOrder = (new Query())
+            ->select('sortOrder')
+            ->from(Table::ELEMENTS_OWNERS)
+            ->where(['elementId' => $elementId, 'ownerId' => $ownerId])
+            ->scalar();
+
+        return $sortOrder === false || $sortOrder === null ? null : (int) $sortOrder;
+    }
+
+    /**
+     * Live sibling ids in current order. Drafts and revisions are excluded so
+     * a pending draft of a sibling never takes its place in the sequence.
+     *
+     * @return int[]
+     */
+    private static function siblingIds(int $ownerId, int $fieldId): array {
+        return array_map(intval(...), (new Query())
+            ->select('eo.elementId')
+            ->from(['eo' => Table::ELEMENTS_OWNERS])
+            ->innerJoin(['e' => Table::ELEMENTS], '[[e.id]] = [[eo.elementId]]')
+            ->innerJoin(['en' => Table::ENTRIES], '[[en.id]] = [[eo.elementId]]')
+            ->where([
+                'eo.ownerId' => $ownerId,
+                'en.fieldId' => $fieldId,
+                'e.dateDeleted' => null,
+                'e.draftId' => null,
+                'e.revisionId' => null,
+            ])
+            ->orderBy(['eo.sortOrder' => SORT_ASC])
+            ->column());
+    }
+}

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -7,6 +7,8 @@ namespace stimmt\craft\Mcp\tools;
 use Craft;
 use craft\elements\Entry;
 use craft\elements\User;
+use craft\fields\Matrix;
+use craft\models\EntryType;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
 use Mcp\Exception\ToolCallException;
@@ -26,6 +28,7 @@ use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\Mcp;
 use stimmt\craft\Mcp\support\Authorization;
 use stimmt\craft\Mcp\support\ElementModule;
+use stimmt\craft\Mcp\support\NestedOrder;
 use stimmt\craft\Mcp\support\ResourceChangeNotifier;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
@@ -231,6 +234,112 @@ class EntryTools {
     }
 
     #[McpTool(
+        name: 'create_nested_entry',
+        description: 'Create a block inside a Matrix field on an owner entry, without resending the owner\'s whole field value. Takes the owner entry id, the Matrix field handle, and the block entry type. Saves as a draft unless mode or the entryWriteMode setting says live; publish_entry attaches it, appended after the existing blocks. Use this instead of read-modify-write via update_entry, which drops any block left out of the payload.',
+        annotations: new ToolAnnotations(destructiveHint: true),
+    )]
+    #[McpToolMeta(category: ToolCategory::CONTENT, dangerous: true)]
+    public function createNestedEntry(
+        int $owner,
+        string $field,
+        string $type,
+        ?string $title = null,
+        ?string $site = null,
+        ?string $fields = null,
+        ?string $mode = null,
+        ?int $position = null,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($owner, $field, $type, $title, $site, $fields, $mode, $position, $context): array {
+            $ownerEntry = $this->find($owner, null, null, $site);
+
+            // The block lives in the owner's content, so the owner is what
+            // authorization is actually about; the block has no section of
+            // its own to check.
+            Authorization::assertCanSave($ownerEntry);
+
+            $matrixField = $this->matrixField($ownerEntry, $field);
+            $entryType = $this->nestedEntryType($matrixField, $type);
+
+            $attributes = array_filter([
+                'type' => Entry::class,
+                'fieldId' => $matrixField->id,
+                'primaryOwnerId' => $ownerEntry->getCanonicalId(),
+                'ownerId' => $ownerEntry->getCanonicalId(),
+                'typeId' => $entryType->id,
+                'siteId' => $ownerEntry->siteId,
+                'title' => $title,
+            ], static fn (mixed $v): bool => $v !== null);
+
+            $result = $this->writer->create($attributes, $this->fieldsPayload($fields), $this->mode($mode), $site);
+
+            if (!$result->isFailure() && $position !== null) {
+                $this->placeBlock($result->draftElementId ?? $result->elementId, $position);
+            }
+
+            if (!$result->isFailure() && $result->state === WriteMode::Live) {
+                ResourceChangeNotifier::notifyEntry($context, $ownerEntry->getCanonicalId());
+            }
+
+            return $result->isFailure()
+                ? ['success' => false] + $result->toArray()
+                : Response::success($result->toArray());
+        }, $context);
+    }
+
+    #[McpTool(
+        name: 'move_nested_entry',
+        description: 'Move a block to a 1-based position within its Matrix field, without resending the owner\'s field value. Position 1 is first; anything past the end lands last. Draft-first like the other write tools: the reorder lands on a draft of the owner unless mode or the entryWriteMode setting says live, and publish_entry applies it.',
+        annotations: new ToolAnnotations(destructiveHint: true),
+    )]
+    #[McpToolMeta(category: ToolCategory::CONTENT, dangerous: true)]
+    public function moveNestedEntry(
+        int $id,
+        int $position,
+        ?string $site = null,
+        ?string $mode = null,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($id, $position, $site, $mode, $context): array {
+            if ($position < 1) {
+                throw new ToolCallException("Position must be 1 or greater, got {$position}");
+            }
+
+            $block = $this->find($id, null, null, $site);
+            if ($block->getOwnerId() === null) {
+                throw new ToolCallException("Entry {$id} is not a block inside a Matrix field; only nested entries have a position");
+            }
+
+            // Authorized against the owner, like create_nested_entry: reordering
+            // changes the owner's content, not the block's own field values.
+            $ownerEntry = $this->find($block->getOwnerId(), null, null, $site);
+            Authorization::assertCanSave($ownerEntry);
+
+            // Order is stored per owner, so drafting a reorder means drafting
+            // the owner and renumbering that draft's rows. The canonical keeps
+            // its order until publish_entry applies the draft.
+            $draft = $this->mode($mode) === WriteMode::Draft && !$ownerEntry->getIsDraft()
+                ? Craft::$app->getDrafts()->createDraft($ownerEntry, $this->authorId())
+                : null;
+
+            $placed = NestedOrder::place($block, $position, $draft === null ? null : (int) $draft->id);
+
+            if ($draft === null) {
+                ResourceChangeNotifier::notifyEntry($context, $ownerEntry->getCanonicalId());
+            }
+
+            return Response::success([
+                'moved' => $id,
+                'owner' => $ownerEntry->getCanonicalId(),
+                'position' => $placed,
+                'state' => $draft === null ? WriteMode::Live->value : WriteMode::Draft->value,
+                'draftElementId' => $draft?->id,
+                'cpEditUrl' => ($draft ?? $ownerEntry)->getCpEditUrl(),
+            ]);
+        }, $context);
+    }
+
+    #[McpTool(
         name: 'update_entry',
         description: 'Update an entry by id. In draft mode (default) a live entry gets a draft on top; publish_entry applies it. fields is payload-format JSON; only supplied values change. Matrix-family blocks are entries too: pass a block\'s own id to edit just that block without touching its siblings.',
         annotations: new ToolAnnotations(destructiveHint: true),
@@ -363,6 +472,56 @@ class EntryTools {
         }
 
         throw new ToolCallException("Entry type '{$handle}' not found in section '{$section->handle}'");
+    }
+
+    /**
+     * Position a freshly created block. Ordering lives in the ownership row,
+     * which exists as soon as the block is saved, so this works on a draft
+     * too: publish_entry preserves the position instead of re-appending.
+     */
+    private function placeBlock(?int $id, int $position): void {
+        $block = $id === null
+            ? null
+            : Entry::find()->id($id)->drafts(null)->status(null)->one();
+
+        if ($block instanceof Entry) {
+            NestedOrder::place($block, $position);
+        }
+    }
+
+    private function matrixField(Entry $owner, string $handle): Matrix {
+        $layout = $owner->getFieldLayout();
+        $available = [];
+
+        foreach ($layout?->getCustomFields() ?? [] as $field) {
+            if (!$field instanceof Matrix) {
+                continue;
+            }
+
+            if ($field->handle === $handle) {
+                return $field;
+            }
+
+            $available[] = $field->handle;
+        }
+
+        $hint = $available === [] ? 'it has none' : 'available: ' . implode(', ', $available);
+
+        throw new ToolCallException("Matrix field '{$handle}' not found on entry {$owner->id} ({$hint})");
+    }
+
+    private function nestedEntryType(Matrix $field, string $handle): EntryType {
+        $available = [];
+
+        foreach ($field->getEntryTypes() as $entryType) {
+            if ($entryType->handle === $handle) {
+                return $entryType;
+            }
+
+            $available[] = $entryType->handle;
+        }
+
+        throw new ToolCallException("Entry type '{$handle}' is not allowed in field '{$field->handle}' (available: " . implode(', ', $available) . ')');
     }
 
     private function fieldsPayload(?string $fields): array {

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -19,6 +19,7 @@ use stimmt\craft\Mcp\elements\Writer;
 use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\support\Authorization;
 use stimmt\craft\Mcp\support\ElementModule;
+use stimmt\craft\Mcp\support\NestedOrder;
 use stimmt\craft\Mcp\support\ResourceChangeNotifier;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
@@ -272,7 +273,13 @@ class EntryWorkflowTools {
      * default draft-first flow, so this is where the resource push belongs.
      */
     private function applyDraft(Entry $draft, ?string $site, ?RequestContext $context): array {
+        // Read the position before applying: for a nested element, applying
+        // cannot recover it and appends instead, so editing one block would
+        // silently move it to the end of its field.
+        $sortOrder = NestedOrder::capture($draft);
         $applied = Craft::$app->getDrafts()->applyDraft($draft);
+        NestedOrder::restore($applied, $sortOrder);
+
         ResourceChangeNotifier::notifyEntry($context, (int) $applied->id);
 
         return Response::success(['entry' => $this->reader->read($applied, $site)]);

--- a/tests/Unit/Support/NestedOrderTest.php
+++ b/tests/Unit/Support/NestedOrderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\support\NestedOrder;
+
+// Reordering is pure database work against elements_owners, so behaviour needs
+// a booted Craft app. These assertions cover the contract and the query shape;
+// the acceptance path is exercised against a real install.
+describe('NestedOrder', function () {
+    it('exposes capture, restore, and place', function (string $method) {
+        expect((new ReflectionClass(NestedOrder::class))->hasMethod($method))->toBeTrue();
+    })->with([['capture'], ['restore'], ['place']]);
+
+    it('treats a non-nested element as having no position', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedOrder::class))->getFileName());
+
+        expect($source)->toContain('instanceof NestedElementInterface');
+    });
+
+    // Restoring is a no-op when applying already left the element where it
+    // was, so an ordinary top-level publish does not write to elements_owners.
+    it('skips the write when the position did not change', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedOrder::class))->getFileName());
+
+        expect($source)->toContain('=== $sortOrder) {');
+    });
+
+    // A trashed block keeps its elements_owners row, so counting it would
+    // leave gaps in the sequence and inflate the max+1 that Craft falls back
+    // to. Renumbering from live siblings only is what closes those gaps.
+    it('renumbers from live siblings, excluding trashed blocks, drafts and revisions', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedOrder::class))->getFileName());
+
+        expect($source)->toContain("'e.dateDeleted' => null")
+            ->and($source)->toContain("'e.draftId' => null")
+            ->and($source)->toContain("'e.revisionId' => null");
+    });
+
+    // Ordering is scoped to one field: an owner with two Matrix fields must
+    // number each independently, or moving a block in one would renumber the
+    // other.
+    it('scopes siblings to the owner and the field together', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedOrder::class))->getFileName());
+
+        expect($source)->toContain("'eo.ownerId' => \$ownerId")
+            ->and($source)->toContain("'en.fieldId' => \$fieldId");
+    });
+
+    it('clamps a position past the end instead of leaving a gap', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedOrder::class))->getFileName());
+
+        expect($source)->toContain('min($position - 1, count($ordered))');
+    });
+
+    // Craft builds its cache tags from whichever element it is handed, and
+    // neither call covers the other: the block contributes its own id and the
+    // container field, the owner contributes its section. Verified against a
+    // live cache, invalidating on the block alone leaves section tags standing
+    // and invalidating on the owner alone leaves field tags standing. A reorder
+    // changes both, so both are invalidated.
+    it('invalidates caches for the block and its owner, not just one', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedOrder::class))->getFileName());
+
+        expect($source)->toContain('foreach ([$element, $owner] as $target)')
+            ->and(substr_count($source, 'self::invalidate($element, $ownerId);'))->toBe(2);
+    });
+
+    // The rows are already written when invalidation runs, so a throw here
+    // would report a reorder that actually happened as a failure.
+    it('never lets a cache failure fail the reorder', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedOrder::class))->getFileName());
+
+        expect($source)->toContain('} catch (Throwable) {');
+    });
+});

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -9,7 +9,7 @@ use stimmt\craft\Mcp\attributes\McpToolMeta;
 use stimmt\craft\Mcp\tools\EntryTools;
 
 describe('EntryTools structure', function () {
-    it('exposes the five tools with expected names', function (string $method, string $name) {
+    it('exposes the seven tools with expected names', function (string $method, string $name) {
         $attributes = (new ReflectionMethod(EntryTools::class, $method))->getAttributes(McpTool::class);
 
         expect($attributes)->toHaveCount(1)
@@ -18,6 +18,8 @@ describe('EntryTools structure', function () {
         ['listEntries', 'list_entries'],
         ['getEntry', 'get_entry'],
         ['createEntry', 'create_entry'],
+        ['createNestedEntry', 'create_nested_entry'],
+        ['moveNestedEntry', 'move_nested_entry'],
         ['updateEntry', 'update_entry'],
         ['describeEntrySchema', 'describe_entry_schema'],
     ]);
@@ -26,7 +28,7 @@ describe('EntryTools structure', function () {
         $meta = (new ReflectionMethod(EntryTools::class, $method))->getAttributes(McpToolMeta::class)[0]->newInstance();
 
         expect($meta->dangerous)->toBeTrue();
-    })->with([['createEntry'], ['updateEntry']]);
+    })->with([['createEntry'], ['createNestedEntry'], ['moveNestedEntry'], ['updateEntry']]);
 
     it('accepts site, mode, and parent parameters on the write tools', function () {
         $params = array_map(
@@ -46,6 +48,146 @@ describe('EntryTools structure', function () {
 
         expect($source)->toContain("\$attributes['parentId'] = \$parentId;")
             ->and($source)->not->toContain('newParentId');
+    });
+});
+
+describe('create_nested_entry', function () {
+    it('targets a block by owner, field and type rather than by section', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(EntryTools::class, 'createNestedEntry'))->getParameters(),
+        );
+
+        expect($params)->toContain('owner')->toContain('field')->toContain('type')
+            ->and($params)->not->toContain('section');
+    });
+
+    it('requires owner, field and type, leaving the rest optional', function (string $name, bool $optional) {
+        $byName = [];
+        foreach ((new ReflectionMethod(EntryTools::class, 'createNestedEntry'))->getParameters() as $p) {
+            $byName[$p->getName()] = $p;
+        }
+
+        expect($byName[$name]->isOptional())->toBe($optional);
+    })->with([
+        ['owner', false],
+        ['field', false],
+        ['type', false],
+        ['title', true],
+        ['site', true],
+        ['fields', true],
+        ['mode', true],
+    ]);
+
+    // A nested entry has no section of its own, so Craft's canSave has nothing
+    // to inspect on the block itself. The block is written into the owner's
+    // content, which makes the owner the element authorization is actually
+    // about -- asserting on a bare new Entry (the create_entry approach) would
+    // check nothing at all here.
+    it('authorizes against the owner entry', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain('Authorization::assertCanSave($ownerEntry);');
+    });
+
+    // Ownership is what attaches the block to the field. primaryOwnerId must be
+    // the canonical id: pointing it at a draft's element id would attach the
+    // block to the draft and lose it when the draft is applied.
+    it('attaches the block through fieldId and the canonical primaryOwnerId', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain("'fieldId' => \$matrixField->id,")
+            ->and($source)->toContain("'primaryOwnerId' => \$ownerEntry->getCanonicalId(),");
+    });
+
+    it('rejects an entry type the target field does not allow', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain('is not allowed in field');
+    });
+
+    it('accepts an optional position, appending when it is omitted', function () {
+        $byName = [];
+        foreach ((new ReflectionMethod(EntryTools::class, 'createNestedEntry'))->getParameters() as $p) {
+            $byName[$p->getName()] = $p;
+        }
+
+        expect($byName)->toHaveKey('position')
+            ->and($byName['position']->isOptional())->toBeTrue()
+            ->and($byName['position']->getDefaultValue())->toBeNull();
+    });
+});
+
+describe('move_nested_entry', function () {
+    it('takes the block id and a target position', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(EntryTools::class, 'moveNestedEntry'))->getParameters(),
+        );
+
+        expect($params)->toContain('id')->toContain('position');
+    });
+
+    // Reordering rewrites the owner's field, so the owner is what may or may
+    // not be writable -- the block's own permissions say nothing about it.
+    it('authorizes against the owner, not the block', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain('Authorization::assertCanSave($ownerEntry);')
+            ->and($source)->toContain('is not a block inside a Matrix field');
+    });
+
+    it('rejects a position below 1 rather than silently clamping', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain('Position must be 1 or greater');
+    });
+
+    // Positions past the end are clamped instead of erroring, so "put it last"
+    // does not require knowing the count first. Returning the position taken
+    // is what makes that unambiguous to the caller.
+    it('reports the position actually taken', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain("'position' => \$placed,");
+    });
+
+    it('honours mode like the other write tools', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(EntryTools::class, 'moveNestedEntry'))->getParameters(),
+        );
+
+        expect($params)->toContain('mode');
+    });
+
+    // Order is stored per owner, so a drafted reorder has to be a draft of the
+    // owner -- there is nothing on the block itself to draft. Without this the
+    // tool would be the only write tool that ignores entryWriteMode and
+    // rearranges a live page with no review step.
+    it('drafts the owner rather than writing the live entry', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain('$this->mode($mode) === WriteMode::Draft && !$ownerEntry->getIsDraft()')
+            ->and($source)->toContain('createDraft($ownerEntry');
+    });
+
+    // The caller needs the owner draft's id to publish it, and publishing is
+    // what makes the reorder live -- returning only the block id would leave
+    // no way to apply it.
+    it('returns the owner draft id and the resulting state', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain("'draftElementId' => \$draft?->id,")
+            ->and($source)->toContain("'state' => \$draft === null ? WriteMode::Live->value : WriteMode::Draft->value,");
+    });
+
+    // A live reorder changes what the canonical entry renders, so subscribers
+    // must hear about it; a drafted one changes nothing live and must not fire.
+    it('notifies resource subscribers only on a live reorder', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
+
+        expect($source)->toContain("if (\$draft === null) {\n                ResourceChangeNotifier::notifyEntry(\$context, \$ownerEntry->getCanonicalId());");
     });
 });
 
@@ -89,10 +231,10 @@ describe('list_entries query surface', function () {
 });
 
 describe('entry write notifications', function () {
-    it('notifies resource subscribers through the shared ResourceChangeNotifier after both create_entry and update_entry', function () {
+    it('notifies resource subscribers through the shared ResourceChangeNotifier after create_entry, update_entry, create_nested_entry and move_nested_entry', function () {
         $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
 
-        expect(substr_count($source, 'ResourceChangeNotifier::notifyEntry('))->toBe(2);
+        expect(substr_count($source, 'ResourceChangeNotifier::notifyEntry('))->toBe(4);
     });
 
     // A draft write (the default entryWriteMode) never touches the canonical
@@ -110,7 +252,7 @@ describe('entry write notifications', function () {
     it('threads the RequestContext through to SafeExecution::run() on the write tools', function () {
         $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
 
-        expect(substr_count($source, '}, $context);'))->toBe(2);
+        expect(substr_count($source, '}, $context);'))->toBe(4);
     });
 });
 

--- a/tests/Unit/Tools/EntryWorkflowToolsTest.php
+++ b/tests/Unit/Tools/EntryWorkflowToolsTest.php
@@ -31,6 +31,23 @@ describe('EntryWorkflowTools structure', function () {
             ->and($source)->toContain('multiple pending drafts')
             ->and($source)->toContain('nothing to publish');
     });
+
+    // A nested element's position lives in elements_owners, which applying a
+    // draft rewrites from max+1 because it cannot recover the previous value.
+    // Without reading it first and putting it back, publishing an edit to one
+    // block silently moves that block to the end of its field.
+    it('preserves a nested block\'s position across applyDraft', function () {
+        $source = (string) file_get_contents((new ReflectionClass(EntryWorkflowTools::class))->getFileName());
+
+        $capture = strpos($source, 'NestedOrder::capture($draft)');
+        $apply = strpos($source, 'applyDraft($draft)');
+        $restore = strpos($source, 'NestedOrder::restore($applied');
+
+        expect($capture)->not->toBeFalse()
+            ->and($restore)->not->toBeFalse()
+            ->and($capture)->toBeLessThan($apply)
+            ->and($restore)->toBeGreaterThan($apply);
+    });
 });
 
 describe('publish_entry resource notification', function () {


### PR DESCRIPTION
Closes #36.

Tested against Craft 5.9.1 / PHP 8.4 on a marketing site whose pages are a single entry with one Matrix field holding 38 block types.

## TL;DR

Craft 5 makes every Matrix block a real entry, and the plugin already edited, deleted and published one through its own id. Creating and ordering had no such path, so both fell back to resending the owner's whole field value, which deletes any block left out of the payload. This adds:

- `create_nested_entry`, targeted by owner id, field handle and block entry type, since a nested entry has no section for `create_entry` to address. This is what #36 asked for.
- An optional `position` on it, so a block can be placed rather than appended.
- `move_nested_entry`, to reorder without resending the owner's field value.
- A fix for a defect that made the documented "safer" path unsafe: editing one block through its own id silently moved it to the end of its field.

Only the first answers a filed issue. The other three came out of building it.

This closes the gap #36 described: editing, removing and publishing a block by its own id already worked, creating one had no direct path, and adding the first block of a type had no workaround at all. Creating, placing and reordering now work the same way, so the whole set is reachable by block id.

One thing before you read the diff: `refactor:dry` is already red on master before this commit, a rector/PHPStan version clash, so please do not read that failure as coming from here. `lint:test`, `analyse` and `test` are all green: 216 files, no errors, 519 tests.

## The ordering fix, and why it needed a new file

Applying a draft of a lone nested element cannot recover its previous `sortOrder` and falls through to `max + 1`. Ownership rows left behind by trashed blocks inflate that maximum further. Reproduced on a live install: a block sitting at `sortOrder 1` landed at `9` after an edit and publish, jumping past every sibling. `docs/content-writing.md` recommends editing a block by its own id as the safe path, and it was safe for content but not for layout.

The fix reads the position before the draft is applied and restores it afterwards.

Ordering lives in `elements_owners.sortOrder`, so `src/support/NestedOrder.php` writes that table directly. **That is the only place in the plugin that writes a Craft core table, so it is worth your judgement rather than mine.** Three things in its defence:

It is what Craft core does. `NestedElementsController::actionReorder()` loops `Db::update(Table::ELEMENTS_OWNERS, ['sortOrder' => $i + 1], ...)` and then calls `invalidateCachesForElement()`, which is the same shape. That logic sits inline in a control-panel-only controller behind `requireCpRequest()` plus session-minted authorization, so a plugin cannot reach it. I have asked Craft to expose it as a service API in craftcms/cms#19321; if that lands, `NestedOrder` collapses into a call to it.

The alternatives inside the public API both cost more than they save. Setting the owner's whole field value and saving is the destructive read-modify-write this PR exists to remove. Setting `sortOrder` per block and calling `saveElement()` means one save per sibling, each firing save events, re-indexing search and potentially creating revisions, for an operation that changes no content at all.

Placement is `src/support/` because that is where the static cross-cutting helpers live (`Authorization`, `ResourceChangeNotifier`, `SiteResolver`). If you would rather it sat in `src/elements/` alongside `Reader`, `Writer` and `refs/`, that is an easy move.

**Cache invalidation looks like belt and braces and is not.** `invalidateCachesForElement()` derives tags from whichever element it receives, and neither call covers the other. Measured against a live cache: invalidating on the block clears the block id, the owner id and the container field but leaves `section` tags standing; invalidating on the owner clears the owner id and `section` but leaves the field tag. A reorder changes both what the field contains and what the owner renders, so both are invalidated. Craft core's own reorder invalidates the owner only.

**The two `catch` blocks are deliberate.** `getField()` and `invalidateCachesForElement()` both walk to `getOwner()`, which throws on an orphaned nested element. Craft added its own try/catch at those two sites in 5.9.0 and 5.9.1 respectively. On 5.9.1 our guards are redundant; on every earlier 5.x they are the only thing between a stray orphan and a thrown reorder. Please do not let them get simplified away by someone testing on a current Craft.

## Ordering is not concurrency-safe, a challenge for another day

`place()` renumbers live siblings contiguously and is collision-free by construction. `restore()` writes one absolute `sortOrder` back, which is the only place in the diff that could produce a tie. Single-threaded it is correct: `capture` and `restore` sit microseconds apart inside one request, and nothing else moves in between. A collision needs two requests interleaving in that window.

I tried the obvious hardening, capturing a position among live siblings and restoring through `place()`, and rejected it: sibling lookup deliberately excludes drafts, and a newly created block is a draft until published, so `create_nested_entry`'s `position` would be silently dropped on publish. The durable version is neighbour-based rather than index-based, which is a challenge for another day.

Related and worth knowing separately: Craft orders nested elements by `sortOrder` with no tiebreaker, so any collision, from any source, silently reshuffles a page with no error. We saw one unexplained instance of a read coming back in element-id order, which is a tie's signature, and could not reproduce it across six-plus attempts. Flagging it as a known unknown rather than leaving it for you to find.

Several things we ran into while building this look like they belong with Craft rather than with this plugin: the missing tiebreaker above, applying a draft losing a nested element's position at all, and trashed blocks keeping ownership rows that inflate the `max + 1` the fallback lands on. We expect to raise a few of those upstream once we understand them well enough to write them up properly. craftcms/cms#19321 was the first.

## Discoverability

`baseInstructions()` gains one numbered item naming the new tools and the rule that targeting a block leaves siblings alone. It costs roughly 70 tokens per connection, taking the field from 3,001 to 3,282 characters.

The reason it is in the instructions rather than only in `docs/content-writing.md` is asymmetry: `instructions` reach every agent unconditionally, while the guide reaches them as a resource, which needs a connected server, a lookup, and the agent choosing to read it.

It is tested, not assumed. An agent given only the docs and the MCP, with no mention of the new tools in its prompt, went straight to `create_nested_entry`, used `position: 1` correctly first try, then `move_nested_entry` first try, with zero tool errors across 36 calls.

## Version floor

Every Craft API this diff touches exists in 5.0.0, and nothing needs more than PHP 8.3. `Table::ELEMENTS_OWNERS` and the nested-element interface are all `@since 5.0.0`, and `Db::update()` is unchanged between 5.0.0 and 5.9.1.

While checking that I noticed the declared `^5.0` does not hold for reasons unrelated to this PR, filed separately as #51. A second thing turned up in the same sweep, #53, about `describe_entry_schema` expanding Matrix block types twice. Neither is bundled here.

## Testing

Added coverage in the existing source-assertion style: `create_nested_entry` and `move_nested_entry` parameter and authorization contracts, the `NestedOrder` invariants, and `applyDraft` position preservation. Two existing tests that count write tools by source text moved from 2 to 3, since the new tools legitimately satisfy the invariants they encode.

Behaviour was exercised against a live install: draft isolation, publish attachment, sibling preservation, positioning, clamping past the end, permission denial for a non-admin content-scope token, and the full create, edit, move, delete round trip.

## Related

A companion PR for #48 (`disabledScopes`, closing a token scope per environment) follows shortly. It shares no source files with this one. I split them because that one carries a behaviour change worth discussing on its own rather than bundled behind a feature, and it will link back here.
