### PR TITLE
feat: disabledScopes closes a token scope per environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `disabledScopes` closes a token scope per environment, alongside `enabled` and `enableDangerousTools`. It applies to admins too, blocks minting in the control panel and in `mcp/tokens/create`, drops the scope from the control panel's scope menu, and rejects existing tokens of that scope at authentication, so disabling a scope closes it rather than only narrowing who may mint one.
+
 ## [1.4.0-beta.9] - 2026-07-20
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,7 @@ return [
 | `disabledTools` | `array` | `[]` | List of tool names to disable regardless of other settings |
 | `disabledPrompts` | `array` | `[]` | List of prompt names to disable |
 | `disabledResources` | `array` | `[]` | List of resource URIs to disable |
+| `disabledScopes` | `array` | `[]` | Token scopes switched off in this environment (`'readonly'`, `'content'`, `'full'`). Applies to admins too, blocks minting in both the control panel and `mcp/tokens/create`, and rejects existing tokens of that scope on every request |
 | `allowedIps` | `array` | `[]` | IP addresses allowed to connect (empty = all allowed) |
 | `logLevel` | `string` | `'error'` | Minimum log level for `storage/logs/mcp-server.log` |
 | `paginationLimit` | `int` | `100` | Page size of MCP list endpoints (`tools/list`, `prompts/list`, `resources/list`); 100 covers every registered tool in one page. Useful when a client does not follow `nextCursor` pagination |
@@ -263,6 +264,20 @@ If you want to allow most tools but restrict a few specific ones, use the `disab
 ```
 
 Tools listed here are disabled regardless of the `enableDangerousTools` setting. Use the snake_case tool name as shown in the [Tools Reference](tools/README.md).
+
+### Disabling Token Scopes
+
+A `full`-scope token carries code execution and skips Craft permission checks, so some environments want it unmintable rather than merely restricted to admins. `disabledScopes` closes a scope per environment:
+
+```php
+'production' => [
+    'disabledScopes' => ['full'],
+],
+```
+
+A disabled scope is refused for everyone, admins included, in the control panel and in `mcp/tokens/create` alike, and it stops being offered in the control panel's scope menu.
+
+It is also checked on every HTTP request, so a token minted before its scope was disabled stops authenticating instead of being grandfathered in. That makes the setting a real guarantee about what can reach the server in an environment, the same way `disabledTools` is for tools, rather than a rule about who may press the button. Re-enabling the scope makes those tokens work again; `mcp/tokens/revoke` still applies if you want them gone permanently.
 
 ## Debugging
 

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -35,7 +35,7 @@ Enabling `httpTransport` registers this route only; it has no effect if `enabled
 Users can mint tokens for themselves via the control panel's My Account screen. Navigate to **My Account** and select **MCP Tokens** from the sidebar, then click **New Token**. Fill in:
 
 - **Name** (required): A display name for this token (e.g., "Anna's Laptop")
-- **Scope**: `readonly` or `content` (default: `content`). Self-service users cannot mint `full`-scope tokens; admins or token managers can.
+- **Scope**: `readonly` or `content` (default: `content`). Self-service users cannot mint `full`-scope tokens; admins or token managers can. Any scope listed in the [`disabledScopes`](configuration.md#disabling-token-scopes) setting is closed in that environment, admins included: it cannot be minted, and existing tokens carrying it are rejected at authentication.
 - **Expires in**: Optional number of days until the token expires; leave blank for a token that never expires.
 
 Click **Create** and the plaintext token appears once, along with a ready-to-paste Claude Desktop configuration snippet:

--- a/src/Mcp.php
+++ b/src/Mcp.php
@@ -15,6 +15,7 @@ use Override;
 use stimmt\craft\Mcp\events\RegisterPromptsEvent;
 use stimmt\craft\Mcp\events\RegisterResourcesEvent;
 use stimmt\craft\Mcp\events\RegisterToolsEvent;
+use stimmt\craft\Mcp\http\Scope;
 use stimmt\craft\Mcp\models\Settings;
 use stimmt\craft\Mcp\services\McpServerFactory;
 use stimmt\craft\Mcp\services\PromptRegistry;
@@ -376,6 +377,18 @@ class Mcp extends BasePlugin {
             : in_array($toolName, self::DANGEROUS_TOOLS, true); // Fallback for backwards compat
 
         return !$isDangerous || $settings->enableDangerousTools;
+    }
+
+    /**
+     * Check whether a token scope may be minted in this environment.
+     *
+     * Deliberately independent of who is asking: a scope switched off in
+     * config is off for admins too, which is the point of being able to close
+     * it per environment. Gates issuance only; tokens minted before the scope
+     * was disabled keep authenticating.
+     */
+    public static function isScopeEnabled(Scope $scope): bool {
+        return !in_array($scope->value, self::settings()->disabledScopes, true);
     }
 
     /**

--- a/src/console/controllers/TokensController.php
+++ b/src/console/controllers/TokensController.php
@@ -65,6 +65,15 @@ class TokensController extends Controller {
             return ExitCode::USAGE;
         }
 
+        // The console runs unauthenticated as whoever has shell access, so
+        // without this check disabledScopes would be a control-panel-only
+        // guardrail that a `php craft` call walks straight past.
+        if (!Mcp::isScopeEnabled($scope)) {
+            $this->stderr("The '{$scope->value}' scope is disabled in this environment (disabledScopes).\n", Console::FG_RED);
+
+            return ExitCode::CONFIG;
+        }
+
         $name = $this->name ?? ($user->username . ' token');
         ['plaintext' => $plaintext] = (new Tokens(new RecordStore()))
             ->create((int) $user->id, $scope, $name, $this->expires);

--- a/src/controllers/CpTokensController.php
+++ b/src/controllers/CpTokensController.php
@@ -149,6 +149,13 @@ final class CpTokensController extends Controller {
     private function authorizeCreate(int $userId, Scope $scope): void {
         $currentUser = self::currentUser();
 
+        // Checked before the admin gate below, and independently of it: a
+        // scope disabled in config is closed to admins too, so the guarantee
+        // does not rest on who happens to hold an admin account.
+        if (!Mcp::isScopeEnabled($scope)) {
+            throw new ForbiddenHttpException(Craft::t('mcp', 'The {scope} scope is disabled in this environment.', ['scope' => $scope->value]));
+        }
+
         // Full scope bypasses all read and write authorization and includes
         // code execution, so only an admin may hand it out; manageAllMcpTokens
         // alone is not enough to mint an admin-equivalent token.
@@ -220,7 +227,9 @@ final class CpTokensController extends Controller {
             $scopes[] = Scope::Full;
         }
 
-        return $scopes;
+        // Keep the form in step with authorizeCreate(): a scope that would be
+        // rejected on submit should not be offered in the first place.
+        return array_values(array_filter($scopes, static fn (Scope $scope): bool => Mcp::isScopeEnabled($scope)));
     }
 
     private function expiresInDays(): ?int {

--- a/src/controllers/HttpController.php
+++ b/src/controllers/HttpController.php
@@ -83,6 +83,14 @@ class HttpController extends Controller {
             return null;
         }
 
+        // Disabling a scope has to close tokens minted before it was disabled
+        // too, otherwise the setting only narrows who can mint one and leaves
+        // every existing token working -- which is the opposite of what
+        // turning a scope off in an environment is for.
+        if (!Mcp::isScopeEnabled($token->scope)) {
+            return null;
+        }
+
         $user = Craft::$app->getUsers()->getUserById($token->userId);
         if ($user === null || $user->suspended || !$user->enabled) {
             return null;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -26,6 +26,20 @@ class Settings extends Model {
     /** @var string[] */
     public array $disabledResources = [];
 
+    /**
+     * Token scopes switched off in this environment, as Scope values
+     * ('readonly', 'content', 'full'). Applies to everyone including admins,
+     * so a scope can be closed per environment the way `enabled` and
+     * `enableDangerousTools` already are.
+     *
+     * Checked at issuance and again on every HTTP request, so a token minted
+     * before its scope was disabled stops authenticating rather than being
+     * grandfathered in -- the same hard guarantee `disabledTools` gives.
+     *
+     * @var string[]
+     */
+    public array $disabledScopes = [];
+
     public bool $enableDangerousTools = true;
 
     /**
@@ -87,6 +101,7 @@ class Settings extends Model {
         return [
             [['enabled', 'enableDangerousTools', 'httpTransport'], 'boolean'],
             [['disabledTools', 'disabledPrompts', 'disabledResources', 'allowedIps', 'scopedTokenPrivilegedTools'], 'each', 'rule' => ['string']],
+            [['disabledScopes'], 'each', 'rule' => ['in', 'range' => ['readonly', 'content', 'full']]],
             [['logLevel'], 'in', 'range' => ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']],
             [['paginationLimit'], 'integer', 'min' => 1],
             [['entryWriteMode'], 'in', 'range' => ['draft', 'live']],

--- a/tests/Unit/Console/TokensControllerTest.php
+++ b/tests/Unit/Console/TokensControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\console\controllers\TokensController;
+
+// TokensController extends craft\console\Controller, which needs a booted
+// yii\base\Module to construct. Craft is never booted in these tests, so
+// assertions are structural, mirroring tests/Unit/Controllers/CpTokensControllerTest.php.
+describe('console TokensController', function () {
+    it('exposes create, list, and revoke actions', function (string $method) {
+        expect((new ReflectionClass(TokensController::class))->hasMethod($method))->toBeTrue();
+    })->with([['actionCreate'], ['actionList'], ['actionRevoke']]);
+
+    // The console runs as whoever has shell access, with no CP permission
+    // check to lean on. If disabledScopes were enforced only in the control
+    // panel, `php craft mcp/tokens/create --scope=full` would walk past it and
+    // the setting would be advisory rather than a guardrail.
+    it('refuses to mint a scope disabled in config', function () {
+        $source = (string) file_get_contents((new ReflectionClass(TokensController::class))->getFileName());
+
+        expect($source)->toContain('Mcp::isScopeEnabled($scope)')
+            ->and($source)->toContain('disabledScopes');
+    });
+
+    it('refuses before creating the token, not after', function () {
+        $source = (string) file_get_contents((new ReflectionClass(TokensController::class))->getFileName());
+
+        expect(strpos($source, 'Mcp::isScopeEnabled($scope)'))
+            ->toBeLessThan(strpos($source, '->create((int) $user->id'));
+    });
+});

--- a/tests/Unit/Controllers/CpTokensControllerTest.php
+++ b/tests/Unit/Controllers/CpTokensControllerTest.php
@@ -102,4 +102,22 @@ describe('CpTokensController', function () {
         expect($source)->toContain('function authorizeRevoke')
             ->and($source)->toContain('$token->userId === $currentUser->id');
     });
+
+    // disabledScopes has to be checked ahead of the admin gate: the point of
+    // closing a scope per environment is that being an admin is no longer
+    // enough to reopen it.
+    it('refuses a scope disabled in config before considering admin status', function () {
+        $source = (string) file_get_contents((new ReflectionClass(CpTokensController::class))->getFileName());
+
+        expect($source)->toContain('Mcp::isScopeEnabled($scope)')
+            ->and(strpos($source, 'Mcp::isScopeEnabled($scope)'))
+            ->toBeLessThan(strpos($source, 'Only admins can mint full-scope'));
+    });
+
+    it('offers only mintable scopes in the form, matching what authorizeCreate accepts', function () {
+        $source = (string) file_get_contents((new ReflectionClass(CpTokensController::class))->getFileName());
+
+        expect($source)->toContain('function allowedScopes')
+            ->and($source)->toContain('static fn (Scope $scope): bool => Mcp::isScopeEnabled($scope)');
+    });
 });

--- a/tests/Unit/Controllers/HttpControllerTest.php
+++ b/tests/Unit/Controllers/HttpControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\controllers\HttpController;
+
+// HttpController extends craft\web\Controller, which needs a booted
+// yii\base\Module to construct. Craft is never booted in these tests, so
+// assertions are structural, mirroring tests/Unit/Controllers/CpTokensControllerTest.php.
+describe('HttpController authentication', function () {
+    // Without this, disabledScopes would only govern who may press the mint
+    // button: every token issued before the scope was closed would keep
+    // working, so switching a scope off in an environment would not actually
+    // close it. Rejecting here is what makes the setting a guarantee about
+    // what can reach the server, matching disabledTools.
+    it('rejects a token whose scope is disabled in this environment', function () {
+        $source = (string) file_get_contents((new ReflectionClass(HttpController::class))->getFileName());
+
+        expect($source)->toContain('Mcp::isScopeEnabled($token->scope)');
+    });
+
+    // The scope check has to sit inside authenticate(), on the path every
+    // request takes, rather than anywhere a single action could bypass.
+    it('checks the scope during authenticate, before the request is served', function () {
+        $source = (string) file_get_contents((new ReflectionClass(HttpController::class))->getFileName());
+
+        $authenticate = strpos($source, 'private function authenticate');
+        $serve = strpos($source, 'private function serve');
+
+        expect(strpos($source, 'Mcp::isScopeEnabled($token->scope)'))
+            ->toBeGreaterThan($authenticate)
+            ->toBeLessThan($serve);
+    });
+
+    // A disabled scope must be indistinguishable from a bad token to the
+    // caller: authenticate() returning null is what produces the standard 401,
+    // rather than leaking that the scope exists but is switched off.
+    it('fails closed by returning null, the same as an unknown token', function () {
+        $source = (string) file_get_contents((new ReflectionClass(HttpController::class))->getFileName());
+
+        $check = strpos($source, 'Mcp::isScopeEnabled($token->scope)');
+        $tail = substr($source, $check, 120);
+
+        expect($tail)->toContain('return null;');
+    });
+});

--- a/tests/Unit/Models/SettingsTest.php
+++ b/tests/Unit/Models/SettingsTest.php
@@ -35,3 +35,22 @@ it('rejects a paginationLimit below 1', function () {
 it('defaults httpSessionStore to null (built-in DB store)', function () {
     expect((new Settings())->httpSessionStore)->toBeNull();
 });
+
+describe('Settings disabledScopes', function () {
+    it('defaults to empty, leaving every scope mintable', function () {
+        expect((new Settings())->disabledScopes)->toBe([]);
+    });
+
+    it('accepts Scope values and rejects anything else', function (array $scopes, bool $valid) {
+        $settings = new Settings();
+        $settings->disabledScopes = $scopes;
+
+        expect($settings->validate(['disabledScopes']))->toBe($valid);
+    })->with([
+        [['full'], true],
+        [['readonly', 'content'], true],
+        [[], true],
+        [['admin'], false],
+        [['Full'], false],
+    ]);
+});


### PR DESCRIPTION
Closes #48.

Independent of #54, which is up separately. No shared source files, so they can be reviewed and merged in either order.

## TL;DR

- `disabledScopes` lists token scopes that can't be used in an environment, alongside `enabled` and `enableDangerousTools`. It applies to admins too.
- Enforced at mint time in the control panel and in `mcp/tokens/create`, and the scope stops being offered in the control panel menu.
- Also enforced at authentication, so a token minted before its scope was disabled stops working on upgrade. That's the one debatable call here, and I'd rather you weigh in than have it land quietly.
- It doesn't touch the `allowedScopes()` versus `authorizeCreate()` mismatch that #48 also raises. Reasons below.

## The behaviour change, first, because it's the part worth arguing about

`disabledScopes` is checked at mint time and again at authentication. That second check means **a token minted before its scope was disabled stops working on upgrade**, rather than being grandfathered in.

That's deliberate, and it's the whole reason the setting is worth having. Closing a scope should close it, the way `disabledTools` is a hard runtime guarantee rather than a rule about who may press the button. If it only gated issuance, an install that had ever minted a full-scope token would still be serving one, and the setting would be a statement of intent rather than a control.

Nothing is destroyed. Re-enabling the scope makes those tokens work again. The rejection is indistinguishable from an unknown token, so it leaks nothing about why.

**If gating issuance only is the preferred behaviour, that's a small change and I'm happy to make it.** It's one guard in `HttpController::authenticate()`. Better to ask than to quietly ship the stricter reading.

## What it does

```php
'production' => [
    'disabledScopes' => ['full'],
],
```

Lists scope values that cannot be used in the current environment, alongside `enabled` and `enableDangerousTools`. It applies to everyone, admins included, which is the point: the guarantee should not rest on trusting whoever holds an admin account that day.

Enforced in four places, because a guard with a way around it isn't a guard:

- `authorizeCreate()`, ahead of the admin check, so a disabled scope is refused before admin status is considered
- `allowedScopes()`, so the control panel stops offering a scope it would reject on submit, which is the dropdown behaviour #48 asks for
- `mcp/tokens/create`, since the console runs unauthenticated as whoever has shell access and would otherwise walk straight past a control-panel-only rule
- `HttpController::authenticate()`, per the section above

The predicate is `Mcp::isScopeEnabled()`, shaped after `isToolEnabled()` so it reads the same way as the existing config gates.

## What I deliberately did not touch

#48 also raises that `allowedScopes()` gates the dropdown on the `manageAllMcpTokens` permission while `authorizeCreate()` gates acceptance on real admin status, so a manager who is not an admin sees "Full" and gets a 403 on submit.

That's still true after this PR. I left it alone because fixing it means choosing which of the two is authoritative, and that's a call about the plugin's permission model rather than a bug with an obvious answer. Happy to follow up on a separate PR once there's a preferred direction.

## Testing

`lint:test`, `analyse` and `test` are green: 216 files, no errors, 500 tests. `refactor:dry` is already red on master before this commit, a rector/PHPStan version clash, so please don't read that failure as coming from here.

Added coverage for the setting's validation, that the config check runs ahead of the admin gate, that the dropdown filter matches what `authorizeCreate()` accepts, that the console path refuses before creating a token, and that authentication fails closed by returning null rather than leaking a distinct error.

Exercised against a live install running Craft 5.9.1: minting `full` from the console refused with exit 78 while `content` still minted, and a token issued before the scope was disabled went from a working `200` to `401` and back to `200` when the scope was re-enabled, with a content-scope token unaffected throughout as a control.
