### PR TITLE
ci: php 8.5 coverage, lefthook hooks, phpstan version-range gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,26 @@
+output:
+  - summary
+  - failure
+
+# The PHP toolchain runs on the host (composer, pint, rector, phpstan, pest),
+# so hooks call composer directly, no DDEV wrapper. Run `lefthook install` once
+# per clone to wire .git/hooks; `composer install` does it automatically via the
+# post-install-cmd script (guarded, no-ops when the lefthook binary is absent).
+
+# Auto-fix staged PHP on commit so nothing unformatted lands. `composer fix`
+# applies rector then pint; stage_fixed re-stages the files it changed.
+pre-commit:
+  jobs:
+    - name: fix
+      glob: "*.php"
+      run: composer fix
+      stage_fixed: true
+
+# Full CI parity before the code leaves the machine: pint check, rector dry-run,
+# phpstan, and the test suite. Mirrors .github/workflows/ci.yml so a red CI is
+# caught here first. Note: the host runs one PHP version, so the 8.3/8.4/8.5
+# compatibility matrix still only runs in CI.
+pre-push:
+  jobs:
+    - name: ci
+      run: composer ci

--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,13 @@
         "pre-commit": [
             "@fix",
             "@ci"
+        ],
+        "lefthook:install": "command -v lefthook >/dev/null 2>&1 && lefthook install || true",
+        "post-install-cmd": [
+            "@lefthook:install"
+        ],
+        "post-update-cmd": [
+            "@lefthook:install"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18",
-        "rector/rector": "2.5.7",
+        "rector/rector": "^2.5",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "phpstan/phpstan": "^2.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,15 @@ rules:
 
 parameters:
     level: 5
+
+    # Analyse against the whole supported PHP range (matches the CI matrix), so
+    # use of a symbol or syntax outside 8.3 to 8.5 is flagged on the host
+    # regardless of the local PHP version. This is the "compatibility" gate that
+    # runs locally via composer analyse and the pre-push hook.
+    phpVersion:
+        min: 80300
+        max: 80500
+
     paths:
         - src
     tmpDir: .phpstan.cache

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
-use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\Config\RectorConfig;
 use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\Set\ValueObject\SetList;
@@ -25,7 +24,6 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         // Skip overly aggressive rules
-        ExplicitBoolCompareRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,
 
         // Keep @deprecated as documentation only. The #[\Deprecated] attribute


### PR DESCRIPTION
Build/dev tooling only; no runtime change, no release needed.

## What changed
- CI: PHP 8.5 added to the Tests and Compatibility matrices (8.3/8.4/8.5).
- PHPStan: `phpVersion` range pinned to 8.3-8.5, so `composer analyse` flags any syntax or symbol outside the supported range regardless of the local PHP version.
- lefthook hooks (`.lefthook.yml`): pre-commit runs `composer fix` on staged PHP files; pre-push runs `composer ci` (pint + rector + phpstan + tests), mirroring CI. Wired automatically via a guarded composer `post-install-cmd` that no-ops when the lefthook binary is absent, so CI runners and plain installs are unaffected.

## Verify
`composer install` on a machine with lefthook prints `sync hooks: (pre-commit, pre-push)`; without lefthook it completes silently. `composer ci` green locally and in CI on all three PHP versions.
