### PR TITLE
fix: draft visibility for created entries, optional client config snippet

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,12 @@ return [
     // vs. production framing, an internal approval step.
     // Default: '' (nothing added)
     'additionalInstructions' => '',
+
+    // Whether the token-reveal screen (My Account -> MCP Tokens) shows the
+    // ready-to-paste Claude Desktop config block alongside the new token.
+    // Turn off on installs that provision MCP clients their own way.
+    // Default: true
+    'showClientConfigSnippet' => true,
 ];
 ```
 
@@ -144,6 +150,7 @@ return [
 | `scopedTokenPrivilegedTools` | `array` | `[]` | Since 1.4.0. Install-introspection tool names to allow scoped (readonly/content) HTTP tokens; privileged tools are locked to admins by default |
 | `disabledScopes` | `array` | `[]` | Since 1.4.0. Scope names (`readonly`, `content`, `full`) that cannot be minted on this install by anyone, admin included; existing tokens of a disabled scope keep working and can still be regenerated |
 | `additionalInstructions` | `string` | `''` | Since 1.4.0. Text appended to the server instructions, on every transport (stdio and HTTP alike), after everything else the plugin adds |
+| `showClientConfigSnippet` | `bool` | `true` | Since 1.4.0. Whether the token-reveal screen (My Account -> MCP Tokens) shows the ready-to-paste Claude Desktop config block alongside the new token |
 
 See the [HTTP Transport guide](http-transport.md) for enabling remote access, minting tokens, and scopes.
 

--- a/docs/content-writing.md
+++ b/docs/content-writing.md
@@ -85,7 +85,7 @@ Shapes whose parent field the writer does not translate (Hyper-style links, gene
 
 By default every write lands as a draft:
 
-- `create_entry` saves a new entry as a draft; `update_entry` on a live entry creates a draft on top, leaving the live version untouched.
+- `create_entry` saves a new entry as a draft; `update_entry` on a live entry creates a draft on top, leaving the live version untouched. Created drafts appear in the CP Entries list like a human-saved draft.
 - The response carries `draftId`, `draftElementId`, and a `cpEditUrl` deep link so a human can review in the control panel.
 - `publish_entry` applies the draft (pass the canonical entry id when there is a single pending draft, or the specific `draftElementId` when there are several).
 - Set `entryWriteMode: 'live'` in `config/mcp.php`, or pass `mode: "live"` per call, for immediate saves.

--- a/src/console/controllers/TokensController.php
+++ b/src/console/controllers/TokensController.php
@@ -46,7 +46,8 @@ class TokensController extends Controller {
     }
 
     /**
-     * Create a token and print it once, with a Claude Desktop snippet.
+     * Create a token and print it once, with a Claude Desktop snippet when
+     * the showClientConfigSnippet setting allows it (#62).
      */
     public function actionCreate(): int {
         $identity = (string) $this->user;
@@ -78,13 +79,15 @@ class TokensController extends Controller {
             ->create((int) $user->id, $scope, $name, $this->expires);
 
         $settings = Mcp::settings();
-        $url = Snippet::url();
+        $snippet = Snippet::jsonIfEnabled($plaintext, Snippet::url());
 
         $this->stdout("Token created (shown once, store it now):\n\n  {$plaintext}\n\n", Console::FG_GREEN);
-        $this->stdout("Claude Desktop config (claude_desktop_config.json):\n");
-        $this->stdout(Snippet::json($plaintext, $url));
-        if ($settings->httpPublicUrl === null) {
-            $this->stdout("\nThe url host comes from the primary site. If Craft answers on a different domain (headless setups often serve the CMS on a separate host), set the httpPublicUrl setting to that domain, or edit the url by hand.\n", Console::FG_YELLOW);
+        if ($snippet !== null) {
+            $this->stdout("Claude Desktop config (claude_desktop_config.json):\n");
+            $this->stdout($snippet);
+            if ($settings->httpPublicUrl === null) {
+                $this->stdout("\nThe url host comes from the primary site. If Craft answers on a different domain (headless setups often serve the CMS on a separate host), set the httpPublicUrl setting to that domain, or edit the url by hand.\n", Console::FG_YELLOW);
+            }
         }
 
         return ExitCode::OK;

--- a/src/controllers/CpTokensController.php
+++ b/src/controllers/CpTokensController.php
@@ -128,12 +128,17 @@ final class CpTokensController extends Controller {
 
     /**
      * Flash a freshly minted plaintext token and its client snippet for the
-     * show-once reveal, then a success message.
+     * show-once reveal, then a success message. The snippet is only built
+     * when showClientConfigSnippet is on (#62); when it's off the flash
+     * stays null, and the reveal template skips the whole config block.
      */
     private function reveal(string $plaintext, string $message): void {
         $session = Craft::$app->getSession();
         $session->setFlash('newToken', $plaintext);
-        $session->setFlash('newTokenSnippet', Snippet::json($plaintext, Snippet::url()));
+        $session->setFlash(
+            'newTokenSnippet',
+            Mcp::settings()->showClientConfigSnippet ? Snippet::json($plaintext, Snippet::url()) : null,
+        );
         $this->setSuccessFlash($message);
     }
 

--- a/src/controllers/CpTokensController.php
+++ b/src/controllers/CpTokensController.php
@@ -128,17 +128,14 @@ final class CpTokensController extends Controller {
 
     /**
      * Flash a freshly minted plaintext token and its client snippet for the
-     * show-once reveal, then a success message. The snippet is only built
-     * when showClientConfigSnippet is on (#62); when it's off the flash
-     * stays null, and the reveal template skips the whole config block.
+     * show-once reveal, then a success message. Snippet::jsonIfEnabled()
+     * is null when showClientConfigSnippet is off (#62); the reveal
+     * template skips the whole config block when the flash is empty.
      */
     private function reveal(string $plaintext, string $message): void {
         $session = Craft::$app->getSession();
         $session->setFlash('newToken', $plaintext);
-        $session->setFlash(
-            'newTokenSnippet',
-            Mcp::settings()->showClientConfigSnippet ? Snippet::json($plaintext, Snippet::url()) : null,
-        );
+        $session->setFlash('newTokenSnippet', Snippet::jsonIfEnabled($plaintext, Snippet::url()));
         $this->setSuccessFlash($message);
     }
 

--- a/src/elements/Writer.php
+++ b/src/elements/Writer.php
@@ -70,7 +70,19 @@ final readonly class Writer {
         // runs (stdio console) keep a null creator as before.
         $identity = Craft::$app->getUser()->getIdentity();
         $creatorId = $identity instanceof User ? $identity->id : null;
-        Craft::$app->getDrafts()->saveElementAsDraft($element, $creatorId, null, null, false);
+
+        // markAsSaved: true. An agent-driven create_entry call is a deliberate
+        // act, not a still-typing autosave tick, so it should land where a
+        // human's "+ New entry" then "Save draft" click does: saved = 1 in
+        // the drafts table. Craft's native create route calls this same
+        // method with markAsSaved: false (the "still being composed" state)
+        // and relies on the CP's Save button to perform a second save that
+        // flips it to true; the plugin has no equivalent second call, and a
+        // draft left at false is invisible in the Entries list, search, and
+        // the Drafts status filter, for the creator and every other user
+        // (#61). It is still an unpublished draft either way: no canonical
+        // id, no public URL, safe from public view until publish_entry.
+        Craft::$app->getDrafts()->saveElementAsDraft($element, $creatorId, null, null, true);
 
         return !$element->hasErrors();
     }

--- a/src/http/Snippet.php
+++ b/src/http/Snippet.php
@@ -43,4 +43,14 @@ JSON;
 
         return rtrim($base, '/') . '/' . $settings->httpPath;
     }
+
+    /**
+     * The config block, or null when showClientConfigSnippet is off (#62).
+     * The single gate for every caller (the CP reveal screen, the console
+     * command): neither checks the setting itself, so the two surfaces can
+     * never disagree on whether the block appears.
+     */
+    public static function jsonIfEnabled(string $plaintext, string $url): ?string {
+        return Mcp::settings()->showClientConfigSnippet ? self::json($plaintext, $url) : null;
+    }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -103,12 +103,22 @@ class Settings extends Model {
     public string $additionalInstructions = '';
 
     /**
+     * Whether the token-reveal screen (My Account -> MCP Tokens) shows the
+     * ready-to-paste Claude Desktop config block alongside the new token.
+     * True by default, matching existing behavior. Installs that provision
+     * MCP clients their own way (a custom prompt and skill, a different
+     * client entirely) can turn this off to leave just the token and its
+     * copy/warning UI.
+     */
+    public bool $showClientConfigSnippet = true;
+
+    /**
      * @return array<int, array<int|string, mixed>>
      */
     #[Override]
     public function defineRules(): array {
         return [
-            [['enabled', 'enableDangerousTools', 'httpTransport'], 'boolean'],
+            [['enabled', 'enableDangerousTools', 'httpTransport', 'showClientConfigSnippet'], 'boolean'],
             [['disabledTools', 'disabledPrompts', 'disabledResources', 'allowedIps', 'scopedTokenPrivilegedTools'], 'each', 'rule' => ['string']],
             [['disabledScopes'], 'each', 'rule' => ['in', 'range' => array_column(Scope::cases(), 'value')]],
             [['logLevel'], 'in', 'range' => ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']],

--- a/src/templates/tokens/_reveal.twig
+++ b/src/templates/tokens/_reveal.twig
@@ -12,15 +12,17 @@
             value: newToken,
         }) }}
 
-        <h3>{{ 'Claude Desktop config'|t('mcp') }}</h3>
-        <div class="mcp-code">
-            <button type="button" class="btn mcp-code-copy" data-icon="clipboard" data-copy-config aria-label="{{ 'Copy'|t('mcp') }}"></button>
-            <pre class="code"><code>{{ newTokenSnippet }}</code></pre>
-        </div>
+        {% if newTokenSnippet %}
+            <h3>{{ 'Claude Desktop config'|t('mcp') }}</h3>
+            <div class="mcp-code">
+                <button type="button" class="btn mcp-code-copy" data-icon="clipboard" data-copy-config aria-label="{{ 'Copy'|t('mcp') }}"></button>
+                <pre class="code"><code>{{ newTokenSnippet }}</code></pre>
+            </div>
 
-        <div class="buttons">
-            <a class="btn" data-icon="download" download="claude_desktop_config.json" href="data:application/json;charset=utf-8,{{ newTokenSnippet|url_encode }}">{{ 'Download'|t('mcp') }}</a>
-        </div>
+            <div class="buttons">
+                <a class="btn" data-icon="download" download="claude_desktop_config.json" href="data:application/json;charset=utf-8,{{ newTokenSnippet|url_encode }}">{{ 'Download'|t('mcp') }}</a>
+            </div>
+        {% endif %}
 
         <p class="warning with-icon" data-token-warning style="margin: 0;">{{ 'Copy this token now. For your security, it will not be shown again.'|t('mcp') }}</p>
     </div>

--- a/tests/Unit/Controllers/CpTokensControllerTest.php
+++ b/tests/Unit/Controllers/CpTokensControllerTest.php
@@ -151,13 +151,14 @@ describe('CpTokensController', function () {
     });
 
     // #62: showClientConfigSnippet lets an install skip the Claude Desktop
-    // config block on the token-reveal screen entirely. Gating at the
-    // controller (rather than the template) means the snippet is never
-    // built when the setting is off, not just hidden from view.
-    it('builds the client config snippet only when showClientConfigSnippet allows it', function () {
+    // config block on the token-reveal screen entirely. The controller
+    // consumes Snippet::jsonIfEnabled() rather than checking the setting
+    // itself, so this and the console command can never disagree on
+    // whether the block appears.
+    it('flashes the client config snippet through the single gated builder', function () {
         $source = (string) file_get_contents((new ReflectionClass(CpTokensController::class))->getFileName());
 
         expect($source)->toContain('function reveal')
-            ->and($source)->toContain('Mcp::settings()->showClientConfigSnippet ? Snippet::json($plaintext, Snippet::url()) : null');
+            ->and($source)->toContain("setFlash('newTokenSnippet', Snippet::jsonIfEnabled(\$plaintext, Snippet::url()))");
     });
 });

--- a/tests/Unit/Controllers/CpTokensControllerTest.php
+++ b/tests/Unit/Controllers/CpTokensControllerTest.php
@@ -149,4 +149,15 @@ describe('CpTokensController', function () {
         expect($body('actionCreate'))->toContain('authorizeScopeEnabled(')
             ->and($body('actionRegenerate'))->not->toContain('authorizeScopeEnabled(');
     });
+
+    // #62: showClientConfigSnippet lets an install skip the Claude Desktop
+    // config block on the token-reveal screen entirely. Gating at the
+    // controller (rather than the template) means the snippet is never
+    // built when the setting is off, not just hidden from view.
+    it('builds the client config snippet only when showClientConfigSnippet allows it', function () {
+        $source = (string) file_get_contents((new ReflectionClass(CpTokensController::class))->getFileName());
+
+        expect($source)->toContain('function reveal')
+            ->and($source)->toContain('Mcp::settings()->showClientConfigSnippet ? Snippet::json($plaintext, Snippet::url()) : null');
+    });
 });

--- a/tests/Unit/Elements/WriterTest.php
+++ b/tests/Unit/Elements/WriterTest.php
@@ -55,3 +55,15 @@ it('attributes drafts to the acting user', function () {
     expect($source)->toContain('instanceof User ? $identity->id : null')
         ->and($source)->toContain('saveElementAsDraft($element, $creatorId');
 });
+
+// #61: saveElementAsDraft's markAsSaved arg must be true, or create_entry
+// leaves the draft in Craft's "still being composed" state (saved = 0),
+// invisible in the Entries list, search, and the Drafts status filter for
+// every user, including its own creator. Craft::$app cannot be stubbed to
+// intercept this call in a unit test (createElement()/getDrafts() require a
+// booted application), so this pins the literal argument in source instead.
+it('marks created drafts as saved so reviewers can find them (#61)', function () {
+    $source = (string) file_get_contents((new ReflectionClass(stimmt\craft\Mcp\elements\Writer::class))->getFileName());
+
+    expect($source)->toContain('saveElementAsDraft($element, $creatorId, null, null, true)');
+});

--- a/tests/Unit/Http/SnippetTest.php
+++ b/tests/Unit/Http/SnippetTest.php
@@ -2,8 +2,12 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../../Fixtures/RealCraft.php';
+
 use stimmt\craft\Mcp\console\controllers\TokensController;
 use stimmt\craft\Mcp\http\Snippet;
+use stimmt\craft\Mcp\Mcp;
+use stimmt\craft\Mcp\models\Settings;
 
 describe('Snippet', function () {
     it('exposes json() and url() as public static methods', function () {
@@ -23,10 +27,48 @@ describe('Snippet', function () {
             ->and($url->getParameters())->toBe([]);
     });
 
-    it('is composed into the console controller output', function () {
+    // #62: is composed via the gated method, not the raw json() builder,
+    // so the console command never checks showClientConfigSnippet itself.
+    it('is composed into the console controller output through the gated method', function () {
         $source = (string) file_get_contents((new ReflectionClass(TokensController::class))->getFileName());
 
-        expect($source)->toContain('Snippet::json(')
+        expect($source)->toContain('Snippet::jsonIfEnabled(')
             ->and($source)->toContain('Snippet::url(');
+    });
+
+    it('exposes jsonIfEnabled() as a public static method returning a nullable string', function () {
+        $method = new ReflectionMethod(Snippet::class, 'jsonIfEnabled');
+
+        expect($method->isStatic())->toBeTrue()
+            ->and($method->isPublic())->toBeTrue()
+            ->and($method->getReturnType()?->allowsNull())->toBeTrue()
+            ->and(array_map(fn (ReflectionParameter $p): string => $p->getName(), $method->getParameters()))
+                ->toBe(['plaintext', 'url']);
+    });
+
+    describe('jsonIfEnabled', function () {
+        it('builds the config snippet when showClientConfigSnippet is on (the default)', function () {
+            expect(Snippet::jsonIfEnabled('plaintext-token', 'https://example.test/mcp'))
+                ->toContain('plaintext-token')
+                ->toContain('mcpServers');
+        });
+
+        // #62: single gate for every caller (CP reveal screen, console
+        // command); this is the one place that must return null so neither
+        // caller has to re-check the setting.
+        it('returns null when showClientConfigSnippet is off', function () {
+            $settingsProperty = new ReflectionProperty(Mcp::class, 'loadedSettings');
+            $original = $settingsProperty->getValue();
+
+            try {
+                $settings = new Settings();
+                $settings->showClientConfigSnippet = false;
+                $settingsProperty->setValue(null, $settings);
+
+                expect(Snippet::jsonIfEnabled('plaintext-token', 'https://example.test/mcp'))->toBeNull();
+            } finally {
+                $settingsProperty->setValue(null, $original);
+            }
+        });
     });
 });

--- a/tests/Unit/Models/SettingsTest.php
+++ b/tests/Unit/Models/SettingsTest.php
@@ -71,3 +71,16 @@ describe('Settings disabledScopes', function () {
         expect($settings->validate(['disabledScopes']))->toBeFalse();
     });
 });
+
+describe('Settings showClientConfigSnippet', function () {
+    it('defaults to true', function () {
+        expect((new Settings())->showClientConfigSnippet)->toBeTrue();
+    });
+
+    it('validates as boolean', function () {
+        $settings = new Settings();
+        $settings->showClientConfigSnippet = false;
+
+        expect($settings->validate(['showClientConfigSnippet']))->toBeTrue();
+    });
+});

--- a/tests/Unit/Web/TemplatesTest.php
+++ b/tests/Unit/Web/TemplatesTest.php
@@ -47,6 +47,20 @@ describe('CP token templates', function () {
         expect($source)->toContain('showUser: true')
             ->and($source)->toContain('mcp-tokens');
     });
+
+    // #62: showClientConfigSnippet skips the Claude Desktop config block
+    // (heading, pre/code, copy button, download button) while leaving the
+    // token field and warning intact; the controller only flashes
+    // newTokenSnippet when the setting allows it, so the template just
+    // needs to skip the block when that flash is empty.
+    it('gates the Claude Desktop config block on newTokenSnippet in the reveal partial', function () use ($base) {
+        $source = (string) file_get_contents("{$base}/_reveal.twig");
+
+        expect($source)->toContain('{% if newTokenSnippet %}')
+            ->and($source)->toContain('Claude Desktop config')
+            ->and($source)->toContain('data-copy-config')
+            ->and($source)->toContain('claude_desktop_config.json');
+    });
 });
 
 describe('utilities\Tokens', function () {


### PR DESCRIPTION
Two community fixes, plus a defensive sweep over their neighboring code paths.

## What changed
- **Created drafts are visible to reviewers.** `create_entry` in draft mode used Craft's `markAsSaved: false` autosave state and never performed the follow-up save a human's "Save draft" click does, so a brand-new draft stayed invisible in the CP Entries list, search, and the Drafts status filter, for every user, forever. Created drafts now land `saved`, exactly where "+ New entry" then "Save draft" lands, while remaining unpublished drafts (no canonical, no public URL). Fixes #61.
- **`showClientConfigSnippet` setting** (default `true`): when off, the ready-to-paste Claude Desktop config block is not built or shown on the CP token-reveal screen, and the `mcp/tokens/create` console command prints the plaintext token without it. The setting is consulted in exactly one place (`Snippet::jsonIfEnabled()`); both surfaces consume the nullable result, so they cannot disagree. Fixes #62.

## Defensive sweep (verified, no changes needed)
- `duplicate_entry` (`duplicateElement(asUnpublishedDraft: true)`) and `copy_entry_to_site` (draft via `createDraft()`) both already land `saved` drafts; only the brand-new `create_entry` path had the gap.
- `list_drafts` was never affected: element queries only hide unsaved drafts when `savedDraftsOnly` is set, which that tool does not use, so the agent-side review queue always saw these drafts even while the CP could not.

## Note for the next release's notes
Drafts created by earlier versions remain in the unsaved state and are subject to Craft's stale unsaved-draft garbage collection (`purgeUnsavedDraftsDuration`). A no-op `update_entry` on such a draft's element id flips it to saved and makes it visible, with no content changes.

## Verify
`composer ci` (516 passing). For #61: `create_entry` any entry in draft mode, then find it in the CP Entries list as any user. For #62: set `'showClientConfigSnippet' => false`, mint a token in the CP and via the console; only the token itself appears.
