### PR TITLE
docs: correct the error shape, report privileged tools in the listing

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -180,6 +180,7 @@ All tools return consistent response structures that AI assistants can easily pa
 
 - **List operations** return `count` and an array of items
 - **Single record lookups** return `found: true/false` with the record or an error message
-- **Operations** return `success: true/false` with data or an error description
+- **Operations** return `success: true` with their data. Failures are not a payload: the tool call
+  itself fails, and the client receives an MCP tool error (`isError: true`) whose text is the reason
 
 See individual tool documentation for specific response formats and examples.

--- a/docs/tools/backup.md
+++ b/docs/tools/backup.md
@@ -90,8 +90,8 @@ create_backup
 
 ```json
 {
-  "success": false,
-  "error": "Unable to create backup: Permission denied"
+  "content": [{ "type": "text", "text": "Unable to create backup: Permission denied" }],
+  "isError": true
 }
 ```
 

--- a/docs/tools/commerce.md
+++ b/docs/tools/commerce.md
@@ -367,12 +367,12 @@ Key fields:
 
 ## Error Handling
 
-If Commerce isn't installed or enabled, all Commerce tools return:
+If Commerce isn't installed or enabled, every Commerce tool fails with:
 
 ```json
 {
-  "success": false,
-  "error": "Craft Commerce is not installed or not enabled"
+  "content": [{ "type": "text", "text": "Craft Commerce is not installed or not enabled" }],
+  "isError": true
 }
 ```
 

--- a/docs/tools/database.md
+++ b/docs/tools/database.md
@@ -204,8 +204,8 @@ run_query sql="SELECT e.id, el.title, el.slug FROM craft_entries e JOIN craft_el
 
 ```json
 {
-  "success": false,
-  "error": "Only SELECT queries are allowed for safety."
+  "content": [{ "type": "text", "text": "Only SELECT queries are allowed for safety." }],
+  "isError": true
 }
 ```
 

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -102,6 +102,7 @@ list_mcp_tools
       "source": "craft-mcp",
       "category": "content",
       "dangerous": false,
+      "privileged": false,
       "enabled": true
     },
     {
@@ -110,6 +111,7 @@ list_mcp_tools
       "source": "craft-mcp",
       "category": "debugging",
       "dangerous": true,
+      "privileged": false,
       "enabled": false
     },
     {
@@ -118,13 +120,14 @@ list_mcp_tools
       "source": "my-plugin",
       "category": "plugin",
       "dangerous": false,
+      "privileged": false,
       "enabled": true
     }
   ]
 }
 ```
 
-Tools are sorted by source, then category, then name. The `enabled` field reflects both the dangerous tools setting and the `disabledTools` configuration, a tool shows as disabled if either condition prevents it from running.
+Tools are sorted by source, then category, then name. The `enabled` field reflects both the dangerous tools setting and the `disabledTools` configuration, a tool shows as disabled if either condition prevents it from running. `privileged` marks the install-introspection reads (logs, config, database structure and contents, environment): they are hidden from readonly and content connections whose Craft user is not an admin, unless the tool is opened through `scopedTokenPrivilegedTools`, so a listed privileged tool can still be unavailable on the connection asking for it.
 
 ---
 

--- a/docs/tools/multisite.md
+++ b/docs/tools/multisite.md
@@ -117,8 +117,8 @@ get_site handle="german"
 
 ```json
 {
-  "success": false,
-  "error": "Site with handle 'nonexistent' not found"
+  "content": [{ "type": "text", "text": "Site with handle 'nonexistent' not found" }],
+  "isError": true
 }
 ```
 

--- a/src/tools/McpTools.php
+++ b/src/tools/McpTools.php
@@ -87,6 +87,11 @@ class McpTools {
                     'source' => $definition->source,
                     'category' => $definition->category,
                     'dangerous' => $definition->dangerous,
+                    // Install-introspection reads are hidden from non-admin
+                    // readonly/content connections, so a listed privileged
+                    // tool can still be refused; say so rather than letting
+                    // the listing imply every row is callable.
+                    'privileged' => $definition->privileged,
                     'enabled' => Mcp::isToolEnabled($definition->name),
                 ];
             }

--- a/tests/Unit/Services/ToolDefinitionSurfaceTest.php
+++ b/tests/Unit/Services/ToolDefinitionSurfaceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../Fixtures/RealCraft.php';
+
+use stimmt\craft\Mcp\Mcp;
+use stimmt\craft\Mcp\tools\McpTools;
+
+// list_mcp_tools advertises tools a scoped token may not actually be allowed
+// to call: the privileged (install-introspection) ones are hidden from
+// non-admin readonly/content connections by the factory. Reporting the flag
+// keeps the listing honest about why a listed tool can be refused.
+it('carries the privileged flag on the definitions the listing is built from', function () {
+    $definitions = Mcp::getToolRegistry()->getDefinitions();
+
+    expect($definitions['read_logs']->privileged)->toBeTrue()
+        ->and($definitions['get_config']->privileged)->toBeTrue()
+        ->and($definitions['list_entries']->privileged)->toBeFalse()
+        ->and($definitions['get_entry']->privileged)->toBeFalse();
+});
+
+// listMcpTools() cannot run headless (its rows need a booted Craft app for
+// ConfigFreshness and isToolEnabled), so the mapping itself is pinned here
+// while the flag's own correctness is covered behaviorally above.
+it('maps the privileged flag into each listing row', function () {
+    $source = (string) file_get_contents((new ReflectionClass(McpTools::class))->getFileName());
+
+    expect($source)->toContain("'privileged' => \$definition->privileged,");
+});


### PR DESCRIPTION
Two accuracy fixes, no behavior change beyond one added response field.

## The error shape the docs described does not exist
`docs/tools/backup.md`, `commerce.md`, `database.md` and `multisite.md` each showed failures as `{"success": false, "error": "..."}`, and `docs/tools/README.md` summarized the same. No tool can return that: `Response` has no error constructor, every failure path throws `ToolCallException`, and the SDK answers with a tool error whose text is the message (`CallToolResult::error()`). The examples now show what a client actually receives, and the summary says so once.

## list_mcp_tools now reports which tools are privileged
The listing advertised install-introspection tools (logs, config, database structure and contents, environment) with nothing to indicate that a readonly or content connection whose user is not an admin will be refused them. Rows now carry `privileged`, documented next to `enabled`.

## Verify
`composer ci`. The flag's correctness is covered behaviorally against the real registry; the row mapping is pinned structurally, since `list_mcp_tools` itself needs a booted Craft app to run.
