### PR TITLE
feat: create and reposition Matrix blocks without rewriting the field

### DIFF
--- a/docs/content-writing.md
+++ b/docs/content-writing.md
@@ -40,6 +40,14 @@ Matrix values are objects keyed by block id (use `new1`, `new2`, ... for new blo
 
 Disabled blocks are preserved on round trips, never silently dropped.
 
+### Block order travels in `position`, not in the key order
+
+Reads add a 1-based `position` to every block, and that is the only reliable statement of the field's order. The blocks are keyed by their numeric entry id, and a JSON object whose keys look like integers is re-ordered ascending by most clients (JavaScript does it by specification), so by the time a payload reaches an agent the keys are usually sorted by id rather than by where the blocks sit on the page.
+
+Writes take `position` back. When every block carries one, the field is saved in that order regardless of the order the keys arrived in; when they are absent, the blocks are saved in the order given, which is what a hand-written payload expects. Either way `position` is stripped before Craft sees it.
+
+This matters because Craft renumbers a Matrix field's order from the order of the value it is handed. Without positions, reading an entry and writing it back unchanged could reshuffle its blocks into id order. Read `position` to learn the order, and change it with `move_nested_entry` rather than by rearranging a payload.
+
 ### Editing one block directly
 
 The block key in the Matrix object above (`new1` in that example) is a placeholder only for a block that doesn't exist yet. For a block `get_entry` already returned, that same key is the block's own entry id, since every Matrix-family block is a real, independently-addressable entry in Craft 5, not a row inside the owner's field.

--- a/docs/content-writing.md
+++ b/docs/content-writing.md
@@ -49,10 +49,12 @@ That id works directly with the entry tools, same as any other entry id:
 - `update_entry id=<blockId> fields='{...}'` edits that one block. Sibling blocks and the owner's own field value are untouched.
 - `delete_entry id=<blockId>` removes that one block.
 - `publish_entry id=<blockId>` applies that block's own pending draft in place.
+- `create_nested_entry owner=<entryId> field=<matrixHandle> type=<blockType>` adds a new block, the first-ever block of a brand-new type included, without resending any sibling.
+- `move_nested_entry id=<blockId> position=<n>` repositions a block within its field.
 
-This is the safer default for a single-block change. Sending the owner's Matrix field through `update_entry` replaces the field's entire value; any block left out of the payload is deleted. Targeting a block's own id skips that risk entirely, since the owner's field value and every sibling block are never touched.
+This is the safer default for any single-block change. Sending the owner's Matrix field through `update_entry` replaces the field's entire value; any block left out of the payload is deleted. Targeting one block skips that risk entirely, since the owner's field value and every sibling block are never touched.
 
-One limit: this only reaches a block whose type already appears somewhere in the field. Adding the first-ever block of a brand new type still needs the full owner-field payload.
+`create_nested_entry` and `move_nested_entry` stage their change on a draft **of the owner entry**, the same way the control panel does: the response's `draftElementId` is the owner draft to review (`get_entry`) and publish (`publish_entry`), and passing it as `owner` to further `create_nested_entry` calls stacks more blocks onto that same draft. After publishing, re-read the owner: Craft duplicates a draft-owned block onto the canonical entry on apply, so the block's final id comes from the published owner, not from the create response.
 
 ## Discover the Shape First: describe_entry_schema
 

--- a/docs/content-writing.md
+++ b/docs/content-writing.md
@@ -56,6 +56,12 @@ This is the safer default for any single-block change. Sending the owner's Matri
 
 `create_nested_entry` and `move_nested_entry` stage their change on a draft **of the owner entry**, the same way the control panel does: the response's `draftElementId` is the owner draft to review (`get_entry`) and publish (`publish_entry`), and passing it as `owner` to further `create_nested_entry` calls stacks more blocks onto that same draft. After publishing, re-read the owner: Craft duplicates a draft-owned block onto the canonical entry on apply, so the block's final id comes from the published owner, not from the create response.
 
+### Conflict detection: expectedDateUpdated
+
+A read-modify-write payload is built from a `get_entry` snapshot, and nothing guarantees that snapshot is still current by the time the write lands: a person may have saved the entry in the control panel in between, or another agent may have published its own draft. `update_entry` accepts an optional `expectedDateUpdated`, the `dateUpdated` string exactly as `get_entry` returned it. When the entry changed since, the write fails naming both timestamps instead of silently overwriting the newer content; re-read, rebuild the payload, retry. Omitting the parameter keeps the previous unchecked behavior.
+
+Prefer avoiding the race entirely where the change allows it: a per-block write (`update_entry` on the block's own id) or `create_nested_entry` never resends sibling content, so there is nothing stale to overwrite.
+
 ## Discover the Shape First: describe_entry_schema
 
 Call `describe_entry_schema` for a section and entry type before writing. It returns everything needed to construct a valid entry on the first attempt:

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -336,6 +336,94 @@ Same shape as `create_entry`, with `action` set to `"updated"`:
 
 ---
 
+### create_nested_entry
+
+Add a single block to a Matrix field on an owner entry, without resending the owner's other blocks. This is the direct "create a card" path: rewriting the owner's whole field value through `update_entry` replaces the field's entire contents and deletes any block left out of the payload, while this tool touches nothing but the new block. It also covers the first-ever block of a type that doesn't appear anywhere in the field yet, which no duplicate-based workaround can reach.
+
+In draft mode (the default) the block lands on a draft **of the owner**, exactly like adding a block in the control panel: siblings and the live page stay untouched until `publish_entry` applies the owner draft. Passing an `owner` that already is a draft's element id stacks the block onto that same draft instead of creating another one.
+
+> **Note:** This is a dangerous tool that can be disabled via configuration.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `owner` | int | Yes | id of the entry that owns the Matrix field; pass a `draftElementId` from an earlier response to stack more blocks onto the same owner draft |
+| `field` | string | Yes | Matrix field handle on the owner |
+| `type` | string | Yes | Entry type handle of the block to create; `describe_entry_schema` lists the valid handles under the field's `blockTypes` |
+| `title` | string | No | Block title, for block types that show one |
+| `fields` | string | No | JSON string in the payload format with the block's custom field values |
+| `site` | string | No | Site handle (defaults to the primary site) |
+| `mode` | string | No | `"draft"` or `"live"`, overriding the `entryWriteMode` setting for this call |
+| `position` | int | No | 1-based position among the field's blocks; omitted appends at the end, past-the-end clamps to the last slot |
+
+**Examples:**
+
+```
+# Add a block at the end of the field, as a draft of the owner
+create_nested_entry owner=123 field="contentBuilder" type="text" fields='{"contentExtensive": "<p>Hello</p>"}'
+
+# Add a quote block as the second block
+create_nested_entry owner=123 field="contentBuilder" type="quote" position=2 fields='{"quote": "Less, but better."}'
+
+# Stack a second block onto the same owner draft
+create_nested_entry owner=890 field="contentBuilder" type="text"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "action": "created",
+  "blockId": 512,
+  "ownerId": 123,
+  "draftId": 14,
+  "draftElementId": 890,
+  "state": "draft",
+  "position": 3,
+  "cpEditUrl": "https://example.com/admin/entries/pages/890-about",
+  "warnings": [],
+  "errors": []
+}
+```
+
+`blockId` is the new block's own entry id. `ownerId` is the canonical owner. `draftElementId` is the **owner draft's** element id: what `publish_entry` accepts, what `get_entry` shows the block in context on, and what follow-up `create_nested_entry`/`update_entry` calls take to keep working on the same draft; both draft keys are `null` for live-mode calls, whose `state` is `"live"`. `position` is the 1-based slot the block actually took (a clamped position reports the real one). After publishing, re-read the owner: Craft duplicates a draft-owned block onto the canonical entry on apply, so the block's final id comes from the published owner, not from this response.
+
+Failure responses carry `success: false` and per-field validation messages under `errors`, same as `create_entry`. Unknown `field` handles fail listing the owner's available Matrix handles; unknown `type` handles fail listing the field's allowed types; revision owners are rejected by name.
+
+---
+
+### move_nested_entry
+
+Move a Matrix block to a new 1-based position within its field, by the block's own entry id. In draft mode (the default) the reorder lands on a draft of the owner entry for review, and `publish_entry` applies it; live mode reorders the canonical entry directly.
+
+> **Note:** This is a dangerous tool that can be disabled via configuration.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | int | Yes | The block's own entry id (the block key `get_entry` returned) |
+| `position` | int | Yes | Target 1-based position; past-the-end clamps to the last slot |
+| `site` | string | No | Site handle (defaults to the primary site) |
+| `mode` | string | No | `"draft"` or `"live"`, overriding the `entryWriteMode` setting for this call |
+
+**Example:**
+
+```
+# Make block 512 the first block of its field, staged on an owner draft
+move_nested_entry id=512 position=1
+```
+
+**Response:**
+
+Same shape as `create_nested_entry`, with `action` set to `"moved"` and `position` reporting the slot actually taken.
+
+The tool rejects, with named errors instead of a silent success: ids that aren't nested elements, draft or revision copies of a block (the message names the canonical block id to use), blocks living in non-Matrix fields (a CKEditor-nested entry's order is markup-driven, so it has no position to move), and owners that are revisions.
+
+---
+
 ### describe_entry_schema
 
 Describe the fields a section/entry type accepts before writing to it: handles, kinds, required flags, a per-field `input` shape describing the exact payload each field takes (natural keys for relations, block types for Matrix, link/option/table/container shapes for structured and third-party fields), native fields, and writable meta attributes. Pass `example` to include a real entry's payload as a golden fixture.

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -299,6 +299,7 @@ Update an entry by id. In draft mode (the default) a live entry gets a draft on 
 | `fields` | string | No | JSON string in the payload format, containing field values to update |
 | `mode` | string | No | `"draft"` or `"live"`, overriding the `entryWriteMode` setting for this call |
 | `parent` | string | No | New parent entry: its numeric id, or its slug within the entry's own section |
+| `expectedDateUpdated` | string | No | The `dateUpdated` string `get_entry` returned; the write fails when the entry changed since, instead of overwriting the newer content |
 
 **Examples:**
 
@@ -314,7 +315,12 @@ update_entry id=123 fields='{"summary": "Updated summary text"}'
 
 # Update live instead of drafting on top
 update_entry id=123 title="New Title" mode="live"
+
+# Reject the write if anything else touched the entry since the read
+update_entry id=123 fields='{"summary": "..."}' expectedDateUpdated="2024-01-15 14:22:00"
 ```
+
+When `expectedDateUpdated` is given and the canonical entry's `dateUpdated` no longer matches it, the call fails naming both timestamps; re-read with `get_entry` and rebuild the payload from the fresh values. Timestamps compare as instants, so timezone formatting differences never produce false conflicts. Omitting the parameter keeps the previous unchecked behavior. See [Content Writing: Conflict detection](../content-writing.md#conflict-detection-expecteddateupdated).
 
 **Response:**
 

--- a/src/elements/refs/Containers.php
+++ b/src/elements/refs/Containers.php
@@ -36,11 +36,69 @@ final readonly class Containers implements FieldTranslator {
     }
 
     public function toKeys(FieldInterface $field, mixed $value, Context $context): mixed {
-        return $this->walk($field, $value, $context, toKeys: true);
+        return $this->numbered($this->walk($field, $value, $context, toKeys: true));
     }
 
     public function toIds(FieldInterface $field, mixed $value, Context $context): mixed {
-        return $this->walk($field, $value, $context, toKeys: false);
+        return $this->walk($field, $this->ordered($value), $context, toKeys: false);
+    }
+
+    /**
+     * Number the blocks in field order on the way out. Order cannot survive the
+     * wire on its own: blocks are keyed by their numeric entry id, and a JSON
+     * object whose keys look like integers is re-ordered ascending by most
+     * clients (JavaScript does it by specification), so the payload an agent
+     * receives is in id order rather than page order. An explicit position
+     * keeps the real order readable no matter what the transport did to the
+     * keys, and move_nested_entry is what changes it.
+     */
+    private function numbered(mixed $value): mixed {
+        if (!$this->isBlockList($value)) {
+            return $value;
+        }
+
+        $position = 0;
+        foreach ($value as $key => $block) {
+            if (is_array($block)) {
+                $value[$key]['position'] = ++$position;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Restore the caller's intended order on the way in, because Craft renumbers
+     * sortOrder from the order of the value it is given: a payload whose keys
+     * were re-ordered in transit would otherwise silently reshuffle the field.
+     * Positions are advisory, so a payload that omits them keeps the order it
+     * arrived in, and the key never reaches Craft either way.
+     */
+    private function ordered(mixed $value): mixed {
+        if (!$this->isBlockList($value)) {
+            return $value;
+        }
+
+        $positioned = array_filter($value, static fn (mixed $block): bool => is_array($block) && isset($block['position']));
+        if (count($positioned) === count($value)) {
+            uasort($value, static fn (array $a, array $b): int => $a['position'] <=> $b['position']);
+        }
+
+        foreach ($value as $key => $block) {
+            if (is_array($block)) {
+                unset($value[$key]['position']);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * A list of blocks keyed by id, as opposed to a single container's own
+     * {fields: ...} value, which carries no ordering of its own.
+     */
+    private function isBlockList(mixed $value): bool {
+        return is_array($value) && !isset($value['fields']);
     }
 
     private function walk(FieldInterface $field, mixed $value, Context $context, bool $toKeys): mixed {

--- a/src/services/McpServerFactory.php
+++ b/src/services/McpServerFactory.php
@@ -272,6 +272,9 @@ class McpServerFactory {
         'get_entry',
         'create_entry',
         'update_entry',
+        'create_nested_entry',
+        'move_nested_entry',
+        'delete_entry',
         'publish_entry',
         'copy_entry_to_site',
         'list_entries',
@@ -358,9 +361,10 @@ This MCP server provides access to a Craft CMS installation.
 1. Call `describe_entry_schema` for the section first; pass `example` (an entry id or slug) to get a real entry as a golden fixture. Every field carries an `input` shape describing the exact payload it accepts.
 2. The payload format is symmetric: what `get_entry` returns is exactly what `create_entry`/`update_entry` accept. Read one, tweak it, write it back.
 3. Use natural keys, never numeric ids: relations are `{"section": "...", "slug": "..."}`, assets `{"volume": "...", "filename": "..."}`, categories/tags `{"group": "...", "slug": "..."}`, users `{"username": "..."}`. Matrix blocks are keyed objects (`new1`, `new2`, ...) with the entry-type handle as `type`.
-4. Writes land as DRAFTS by default: the response carries `draftElementId` and a `cpEditUrl` deep link for human review; `publish_entry` makes them live. Nothing touches live content until published.
-5. Always read the `warnings` list on write responses: unresolvable natural keys become warnings, never guesses or silent drops. Validation failures return per-field errors.
-6. Multi-site installs: pass the `site` handle parameter; `copy_entry_to_site` moves content between sites.
+4. Single Matrix-block work has dedicated tools: `create_nested_entry` adds one block to an owner's field without resending its siblings, `move_nested_entry` repositions one, and `update_entry`/`delete_entry` with the block's own id edit or remove one. Prefer these over rewriting the owner's whole field value, which deletes any block left out of the payload.
+5. Writes land as DRAFTS by default: the response carries `draftElementId` and a `cpEditUrl` deep link for human review; `publish_entry` makes them live. Nothing touches live content until published.
+6. Always read the `warnings` list on write responses: unresolvable natural keys become warnings, never guesses or silent drops. Validation failures return per-field errors.
+7. Multi-site installs: pass the `site` handle parameter; `copy_entry_to_site` moves content between sites.
 
 The full contract lives in the `craft://guides/content-writing` resource.
 
@@ -369,11 +373,12 @@ The full contract lives in the `craft://guides/content-writing` resource.
 Prefer the most specific tool and escalate only when none fits:
 
 1. Content questions: `list_entries` (field filters, `relatedTo`, `search`, date ranges, `fields` projection), `get_entry`, `count_entries` for totals and per-value breakdowns, `list_drafts` for the review queue, `list_revisions` for an entry's history, `describe_entry_schema` for payload shapes.
-2. Other element types and nested shapes: `query_graphql` reads anything Craft's GraphQL schema exposes (assets, categories, users, plugin types) with exactly the response shape you ask for.
-3. Database structure: `get_database_schema` and `get_table_counts`, never hand-written information_schema queries.
-4. `run_query` covers what no structured tool does: custom plugin tables and aggregate SQL (SELECT only).
-5. `tinker` is the last resort, for logic no tool can express (cross-entry computation, service calls). Keep analysis code read-only; write content through the entry tools so drafts, validation, and warnings stay in play.
-6. Tools marked with a destructive annotation modify data or execute code; prefer draft-mode writes and review flows.
+2. Single Matrix-block changes: `create_nested_entry` to add a block, `move_nested_entry` to reposition one, `update_entry`/`delete_entry` with the block's own id to edit or remove one. Never rebuild an owner's whole field value to change one block.
+3. Other element types and nested shapes: `query_graphql` reads anything Craft's GraphQL schema exposes (assets, categories, users, plugin types) with exactly the response shape you ask for.
+4. Database structure: `get_database_schema` and `get_table_counts`, never hand-written information_schema queries.
+5. `run_query` covers what no structured tool does: custom plugin tables and aggregate SQL (SELECT only).
+6. `tinker` is the last resort, for logic no tool can express (cross-entry computation, service calls). Keep analysis code read-only; write content through the entry tools so drafts, validation, and warnings stay in play.
+7. Tools marked with a destructive annotation modify data or execute code; prefer draft-mode writes and review flows.
 INSTRUCTIONS;
     }
 

--- a/src/services/ToolRegistry.php
+++ b/src/services/ToolRegistry.php
@@ -20,6 +20,7 @@ use stimmt\craft\Mcp\tools\EntryWorkflowTools;
 use stimmt\craft\Mcp\tools\GlobalSetTools;
 use stimmt\craft\Mcp\tools\GraphqlTools;
 use stimmt\craft\Mcp\tools\McpTools;
+use stimmt\craft\Mcp\tools\NestedEntryTools;
 use stimmt\craft\Mcp\tools\SiteTools;
 use stimmt\craft\Mcp\tools\SystemTools;
 use stimmt\craft\Mcp\tools\TinkerTools;
@@ -49,6 +50,7 @@ final class ToolRegistry {
         GlobalSetTools::class,
         GraphqlTools::class,
         McpTools::class,
+        NestedEntryTools::class,
         SiteTools::class,
         SystemTools::class,
         TinkerTools::class,

--- a/src/support/NestedPosition.php
+++ b/src/support/NestedPosition.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\base\NestedElementInterface;
+use craft\db\Query;
+use craft\db\Table;
+use craft\elements\db\ElementQueryInterface;
+use craft\elements\Entry;
+use craft\fields\Matrix;
+use Mcp\Exception\ToolCallException;
+
+/**
+ * The two position primitives for nested Matrix blocks: capture the position
+ * a block currently holds under its owner, and move a block to a new one.
+ * Reordering goes through Craft's supported owner-save path (set the field
+ * value to the reordered block collection, save the owner) instead of raw
+ * elements_owners writes: NestedElementManager::saveNestedElements() then
+ * renumbers by value order inside its own transaction, skips unchanged rows,
+ * and handles change tracking and cache invalidation itself.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class NestedPosition {
+    /**
+     * The 1-based position the element currently holds under its owner, or
+     * null when the element is not nested. Reads the CANONICAL block's
+     * current elements_owners row: a draft's own row still carries the
+     * position from draft-creation time, so a block reordered after being
+     * drafted must not publish back to that stale spot.
+     */
+    public static function capture(ElementInterface $element): ?int {
+        if (!$element instanceof NestedElementInterface) {
+            return null;
+        }
+
+        $ownerId = $element->getOwnerId();
+        if ($ownerId === null) {
+            return null;
+        }
+
+        $sortOrder = (new Query())
+            ->select(['sortOrder'])
+            ->from(Table::ELEMENTS_OWNERS)
+            ->where(['elementId' => $element->getCanonicalId(), 'ownerId' => $ownerId])
+            ->scalar();
+
+        return is_numeric($sortOrder) ? (int) $sortOrder : null;
+    }
+
+    /**
+     * Move a block to a 1-based position within its field on $owner and
+     * return the position actually taken (positions past the end clamp to
+     * the last slot). $blockId is the canonical block id; blocks are matched
+     * on getCanonicalId() because under a saved owner draft an edited block
+     * is a shed copy whose own element id differs from the canonical.
+     */
+    public static function move(Entry $owner, Matrix $field, int $blockId, int $position): int {
+        $value = $owner->getFieldValue($field->handle);
+        if (!$value instanceof ElementQueryInterface) {
+            throw new ToolCallException(
+                "Field '{$field->handle}' on entry {$owner->id} did not return a block query; the blocks cannot be reordered safely.",
+            );
+        }
+
+        // status(null) is mandatory: core's owner-save cleanup deletes any
+        // block missing from the value, so disabled siblings must ride along.
+        $blocks = $value->status(null)->all();
+
+        $byCanonicalId = [];
+        foreach ($blocks as $block) {
+            $byCanonicalId[(int) $block->getCanonicalId()] = $block;
+        }
+
+        if (!isset($byCanonicalId[$blockId])) {
+            throw new ToolCallException(
+                "Block {$blockId} is not among the blocks of field '{$field->handle}' on entry {$owner->id}; it may belong to a different owner, field, or site.",
+            );
+        }
+
+        [$order, $taken] = self::reorder(array_keys($byCanonicalId), $blockId, $position);
+
+        $value->setCachedResult(array_map(static fn (int $id): ElementInterface => $byCanonicalId[$id], $order));
+        $owner->setFieldValue($field->handle, $value);
+
+        if (!Craft::$app->getElements()->saveElement($owner)) {
+            throw new ToolCallException('Failed to reorder blocks: ' . json_encode($owner->getErrors()));
+        }
+
+        return $taken;
+    }
+
+    /**
+     * Pure reorder arithmetic: remove $blockId from the id list, clamp
+     * $position into [1..count], reinsert, and return the new order plus the
+     * position taken. Separated from move() so the arithmetic tests without
+     * a Craft application.
+     *
+     * @param int[] $ids canonical block ids in current field order
+     * @return array{0: int[], 1: int}
+     */
+    public static function reorder(array $ids, int $blockId, int $position): array {
+        if ($position < 1) {
+            throw new ToolCallException("position must be 1 or greater, got {$position}");
+        }
+
+        $index = array_search($blockId, $ids, true);
+        if ($index === false) {
+            throw new ToolCallException("Block {$blockId} is not in the block list");
+        }
+
+        unset($ids[$index]);
+        $ids = array_values($ids);
+
+        $taken = min($position, count($ids) + 1);
+        array_splice($ids, $taken - 1, 0, [$blockId]);
+
+        return [$ids, $taken];
+    }
+}

--- a/src/support/WriteParams.php
+++ b/src/support/WriteParams.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Mcp\Exception\ToolCallException;
+use stimmt\craft\Mcp\elements\WriteMode;
+use stimmt\craft\Mcp\Mcp;
+
+/**
+ * Shared parsing for the write-tool parameters every entry write accepts:
+ * the JSON fields payload and the draft/live mode. One home instead of a
+ * per-tool-class copy, so a message or default changed here changes
+ * everywhere.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final class WriteParams {
+    /**
+     * @return array<array-key, mixed>
+     */
+    public static function fieldsPayload(?string $fields): array {
+        if ($fields === null) {
+            return [];
+        }
+
+        $decoded = json_decode($fields, true);
+        if (!is_array($decoded)) {
+            throw new ToolCallException('Invalid JSON in fields parameter');
+        }
+
+        return $decoded;
+    }
+
+    public static function mode(?string $mode): WriteMode {
+        if ($mode !== null) {
+            return WriteMode::tryFrom(strtolower($mode))
+                ?? throw new ToolCallException("Unknown mode '{$mode}'; use draft or live");
+        }
+
+        return WriteMode::fromSetting(Mcp::settings()->entryWriteMode);
+    }
+}

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -23,13 +23,13 @@ use stimmt\craft\Mcp\elements\schema\Meta;
 use stimmt\craft\Mcp\elements\WriteMode;
 use stimmt\craft\Mcp\elements\Writer;
 use stimmt\craft\Mcp\enums\ToolCategory;
-use stimmt\craft\Mcp\Mcp;
 use stimmt\craft\Mcp\support\Authorization;
 use stimmt\craft\Mcp\support\ElementModule;
 use stimmt\craft\Mcp\support\ResourceChangeNotifier;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
 use stimmt\craft\Mcp\support\SiteResolver;
+use stimmt\craft\Mcp\support\WriteParams;
 
 /**
  * Entry tools: payload-format reads, draft-first writes, schema discovery.
@@ -218,7 +218,7 @@ class EntryTools {
                 $attributes['parentId'] = $parentId;
             }
 
-            $result = $this->writer->create($attributes, $this->fieldsPayload($fields), $this->mode($mode), $site);
+            $result = $this->writer->create($attributes, WriteParams::fieldsPayload($fields), WriteParams::mode($mode), $site);
 
             if (!$result->isFailure() && $result->state === WriteMode::Live && $result->elementId !== null) {
                 ResourceChangeNotifier::notifyEntry($context, $result->elementId);
@@ -265,7 +265,7 @@ class EntryTools {
                 $attributes['parentId'] = $parentId;
             }
 
-            $result = $this->writer->update($entry, $attributes, $this->fieldsPayload($fields), $this->mode($mode), $site);
+            $result = $this->writer->update($entry, $attributes, WriteParams::fieldsPayload($fields), WriteParams::mode($mode), $site);
 
             if (!$result->isFailure() && $result->state === WriteMode::Live && $result->elementId !== null) {
                 ResourceChangeNotifier::notifyEntry($context, $result->elementId);
@@ -363,30 +363,6 @@ class EntryTools {
         }
 
         throw new ToolCallException("Entry type '{$handle}' not found in section '{$section->handle}'");
-    }
-
-    private function fieldsPayload(?string $fields): array {
-        if ($fields === null) {
-            return [];
-        }
-
-        $decoded = json_decode($fields, true);
-        if (!is_array($decoded)) {
-            throw new ToolCallException('Invalid JSON in fields parameter');
-        }
-
-        return $decoded;
-    }
-
-    private function mode(?string $mode): WriteMode {
-        if ($mode !== null) {
-            return WriteMode::tryFrom(strtolower($mode))
-                ?? throw new ToolCallException("Unknown mode '{$mode}'; use draft or live");
-        }
-
-        $settings = Mcp::settings();
-
-        return WriteMode::fromSetting($settings->entryWriteMode);
     }
 
     private function parentId(?string $parent, ?string $section, ?string $site): ?int {

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -7,6 +7,8 @@ namespace stimmt\craft\Mcp\tools;
 use Craft;
 use craft\elements\Entry;
 use craft\elements\User;
+use DateTimeImmutable;
+use Exception;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
 use Mcp\Exception\ToolCallException;
@@ -232,7 +234,7 @@ class EntryTools {
 
     #[McpTool(
         name: 'update_entry',
-        description: 'Update an entry by id. In draft mode (default) a live entry gets a draft on top; publish_entry applies it. fields is payload-format JSON; only supplied values change. Matrix-family blocks are entries too: pass a block\'s own id to edit just that block without touching its siblings.',
+        description: 'Update an entry by id. In draft mode (default) a live entry gets a draft on top; publish_entry applies it. fields is payload-format JSON; only supplied values change. Matrix-family blocks are entries too: pass a block\'s own id to edit just that block without touching its siblings. Pass expectedDateUpdated (the dateUpdated string get_entry returned) to fail instead of overwriting when the entry changed since your read.',
         annotations: new ToolAnnotations(destructiveHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::CONTENT, dangerous: true)]
@@ -245,11 +247,13 @@ class EntryTools {
         ?string $fields = null,
         ?string $mode = null,
         ?string $parent = null,
+        ?string $expectedDateUpdated = null,
         ?RequestContext $context = null,
     ): array {
-        return SafeExecution::run(function () use ($id, $site, $title, $slug, $status, $fields, $mode, $parent, $context): array {
+        return SafeExecution::run(function () use ($id, $site, $title, $slug, $status, $fields, $mode, $parent, $expectedDateUpdated, $context): array {
             $entry = $this->find($id, null, null, $site);
             Authorization::assertCanSave($entry);
+            $this->assertUnchanged($entry, $expectedDateUpdated);
 
             $attributes = array_filter([
                 'title' => $title,
@@ -363,6 +367,40 @@ class EntryTools {
         }
 
         throw new ToolCallException("Entry type '{$handle}' not found in section '{$section->handle}'");
+    }
+
+    /**
+     * Optional optimistic-concurrency precondition (#36): a read-modify-write
+     * payload built from a get_entry snapshot is rejected when the canonical
+     * entry changed underneath it, instead of silently overwriting whatever
+     * changed. Timestamps compare as instants so timezone formatting
+     * differences never produce false conflicts; omitted means unchecked.
+     */
+    private function assertUnchanged(Entry $entry, ?string $expectedDateUpdated): void {
+        if ($expectedDateUpdated === null) {
+            return;
+        }
+
+        $current = $entry->getCanonical()->dateUpdated;
+        if ($current === null || $current->getTimestamp() === $this->timestamp($expectedDateUpdated)) {
+            return;
+        }
+
+        throw new ToolCallException(
+            "Entry {$entry->getCanonicalId()} changed since you read it: dateUpdated is now"
+            . " '{$current->format('Y-m-d H:i:s')}', expectedDateUpdated was '{$expectedDateUpdated}'."
+            . ' Re-read the entry with get_entry and rebuild the write from the fresh payload.',
+        );
+    }
+
+    private function timestamp(string $value): int {
+        try {
+            return (new DateTimeImmutable($value))->getTimestamp();
+        } catch (Exception) {
+            throw new ToolCallException(
+                "Invalid expectedDateUpdated '{$value}'; pass the dateUpdated string exactly as get_entry returned it.",
+            );
+        }
     }
 
     private function parentId(?string $parent, ?string $section, ?string $site): ?int {

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -19,6 +19,7 @@ use stimmt\craft\Mcp\elements\Writer;
 use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\support\Authorization;
 use stimmt\craft\Mcp\support\ElementModule;
+use stimmt\craft\Mcp\support\NestedPosition;
 use stimmt\craft\Mcp\support\ResourceChangeNotifier;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
@@ -272,6 +273,16 @@ class EntryWorkflowTools {
      * default draft-first flow, so this is where the resource push belongs.
      */
     private function applyDraft(Entry $draft, ?string $site, ?RequestContext $context): array {
+        // A nested block's draft must carry the canonical's current position
+        // into the apply, or Craft appends the block to the end of its field:
+        // applyDraft clones with draftId nulled, which skips saveOwnership()'s
+        // sortOrder recovery and falls through to max+1. Presetting the value
+        // writes the right position inside the apply transaction.
+        $sortOrder = NestedPosition::capture($draft);
+        if ($sortOrder !== null) {
+            $draft->setSortOrder($sortOrder);
+        }
+
         $applied = Craft::$app->getDrafts()->applyDraft($draft);
         ResourceChangeNotifier::notifyEntry($context, (int) $applied->id);
 

--- a/src/tools/EntryWorkflowTools.php
+++ b/src/tools/EntryWorkflowTools.php
@@ -24,6 +24,7 @@ use stimmt\craft\Mcp\support\ResourceChangeNotifier;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
 use stimmt\craft\Mcp\support\SiteResolver;
+use stimmt\craft\Mcp\support\WriteParams;
 
 /**
  * Entry workflow: the pending-drafts review queue, publish, delete, duplicate, copy to site.
@@ -177,16 +178,12 @@ class EntryWorkflowTools {
             $attributes = array_filter(['title' => $title, 'slug' => $slug], static fn (?string $v): bool => $v !== null);
             $duplicate = Craft::$app->getElements()->duplicateElement($entry, $attributes, asUnpublishedDraft: true);
 
-            if ($fields !== null) {
-                $decoded = json_decode($fields, true);
-                if (!is_array($decoded)) {
-                    throw new ToolCallException('Invalid JSON in fields parameter');
-                }
+            $result = $fields === null
+                ? null
+                : $this->writer->update($duplicate, [], WriteParams::fieldsPayload($fields), WriteMode::Draft, $site);
 
-                $result = $this->writer->update($duplicate, [], $decoded, WriteMode::Draft, $site);
-                if ($result->isFailure()) {
-                    return ['success' => false] + $result->toArray();
-                }
+            if ($result !== null && $result->isFailure()) {
+                return ['success' => false] + $result->toArray();
             }
 
             return Response::success(['entry' => $this->reader->read($duplicate, $site)]);

--- a/src/tools/NestedEntryTools.php
+++ b/src/tools/NestedEntryTools.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\tools;
+
+use Craft;
+use craft\elements\db\ElementQueryInterface;
+use craft\elements\Entry;
+use craft\fields\Matrix;
+use craft\models\EntryType;
+use craft\models\FieldLayout;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use Mcp\Schema\ToolAnnotations;
+use Mcp\Server\RequestContext;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\elements\Result;
+use stimmt\craft\Mcp\elements\Warning;
+use stimmt\craft\Mcp\elements\WriteMode;
+use stimmt\craft\Mcp\elements\Writer;
+use stimmt\craft\Mcp\enums\ToolCategory;
+use stimmt\craft\Mcp\support\Authorization;
+use stimmt\craft\Mcp\support\ElementModule;
+use stimmt\craft\Mcp\support\NestedPosition;
+use stimmt\craft\Mcp\support\ResourceChangeNotifier;
+use stimmt\craft\Mcp\support\Response;
+use stimmt\craft\Mcp\support\SafeExecution;
+use stimmt\craft\Mcp\support\SiteResolver;
+use stimmt\craft\Mcp\support\WriteParams;
+use Throwable;
+
+/**
+ * Nested Matrix block writes on the owner-draft model: a pending block lives
+ * on a draft OF THE OWNER, exactly like a control panel edit, so canonical
+ * content and sibling blocks stay untouched until publish_entry applies the
+ * owner draft. Never attach a pending block to the canonical owner instead:
+ * Craft's owner-save cleanup (NestedElementManager::deleteOtherNestedElements)
+ * hard-deletes unpublished draft blocks whose primary owner is the canonical,
+ * so any human edit of the owner would silently destroy the block.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+class NestedEntryTools {
+    private const string ACTION_MOVED = 'moved';
+
+    private readonly Writer $writer;
+
+    public function __construct(?Writer $writer = null) {
+        $this->writer = $writer ?? ElementModule::writer();
+    }
+
+    #[McpTool(
+        name: 'create_nested_entry',
+        description: 'Add a block to a Matrix field on an owner entry without resending the field\'s other blocks (the full-field rewrite risks deleting them). In draft mode (default) the block lands on a draft of the owner, like a control panel edit: pass the returned draftElementId to publish_entry to make it live, to get_entry to review it in context, or as owner in follow-up calls to stack more blocks onto the same draft. Optional position places the block among its siblings (1-based, clamped to the end).',
+        annotations: new ToolAnnotations(destructiveHint: true),
+    )]
+    #[McpToolMeta(category: ToolCategory::CONTENT, dangerous: true)]
+    public function createNestedEntry(
+        int $owner,
+        string $field,
+        string $type,
+        ?string $title = null,
+        ?string $fields = null,
+        ?string $site = null,
+        ?string $mode = null,
+        ?int $position = null,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($owner, $field, $type, $title, $fields, $site, $mode, $position, $context): array {
+            $this->assertPosition($position);
+            $payload = WriteParams::fieldsPayload($fields);
+            $writeMode = WriteParams::mode($mode);
+
+            $ownerEntry = $this->ownerFor($owner, $site);
+            Authorization::assertCanSave($ownerEntry->getCanonical());
+
+            $matrix = $this->matrixField($ownerEntry->getFieldLayout(), $field);
+            $entryType = $this->blockType($matrix, $type);
+            $target = $this->target($ownerEntry, $writeMode);
+
+            $result = $this->writer->create($this->blockAttributes($entryType, $matrix, $target, $title), $payload, WriteMode::Live, $site);
+            if ($result->isFailure()) {
+                return ['success' => false] + $result->toArray();
+            }
+
+            $blockId = (int) $result->elementId;
+            $taken = $position === null
+                ? $this->endPosition($target, $matrix)
+                : NestedPosition::move($target, $matrix, $blockId, $position);
+
+            $this->notifyOwner($context, $target);
+
+            return Response::success($this->blockResponse(Result::ACTION_CREATED, $blockId, $target, $taken, $result->warnings));
+        }, $context);
+    }
+
+    #[McpTool(
+        name: 'move_nested_entry',
+        description: 'Move a Matrix block to a new 1-based position within its field, by the block\'s own entry id. In draft mode (default) the reorder lands on a draft of the owner entry for review and publish_entry applies it; live mode reorders the canonical directly. Positions past the end clamp to the last slot; the response reports the position actually taken.',
+        annotations: new ToolAnnotations(destructiveHint: true),
+    )]
+    #[McpToolMeta(category: ToolCategory::CONTENT, dangerous: true)]
+    public function moveNestedEntry(
+        int $id,
+        int $position,
+        ?string $site = null,
+        ?string $mode = null,
+        ?RequestContext $context = null,
+    ): array {
+        return SafeExecution::run(function () use ($id, $position, $site, $mode, $context): array {
+            $this->assertPosition($position);
+            $writeMode = WriteParams::mode($mode);
+
+            $block = $this->blockFor($id, $site);
+            $matrix = $this->matrixFieldOf($block);
+            $ownerEntry = $this->ownerFor((int) $block->getOwnerId(), $site);
+            Authorization::assertCanSave($ownerEntry->getCanonical());
+
+            $target = $this->target($ownerEntry, $writeMode);
+            $taken = NestedPosition::move($target, $matrix, (int) $block->id, $position);
+
+            $this->notifyOwner($context, $target);
+
+            return Response::success($this->blockResponse(self::ACTION_MOVED, (int) $block->id, $target, $taken));
+        }, $context);
+    }
+
+    private function assertPosition(?int $position): void {
+        if ($position === null || $position >= 1) {
+            return;
+        }
+
+        throw new ToolCallException("position must be 1 or greater, got {$position}");
+    }
+
+    /**
+     * Id lookup across every element state: drafts are legal owners (the
+     * whole point of the owner-draft model) and revisions must be FOUND so
+     * they can be rejected with a message naming the canonical, instead of a
+     * blind "not found".
+     */
+    private function find(int $id, ?string $site): Entry {
+        SiteResolver::resolve($site);
+
+        $query = Entry::find()->id($id)->status(null)->drafts(null)->revisions(null);
+        if ($site !== null) {
+            $query->site($site);
+        }
+
+        return $query->one() ?? throw new ToolCallException("Entry {$id} not found");
+    }
+
+    private function ownerFor(int $id, ?string $site): Entry {
+        $owner = $this->find($id, $site);
+        if ($owner->getIsRevision()) {
+            throw new ToolCallException(
+                "Entry {$id} is a revision; revisions are read-only history and cannot receive or reorder blocks. Target the canonical entry {$owner->getCanonicalId()} instead.",
+            );
+        }
+
+        return $owner;
+    }
+
+    /**
+     * The block a move targets, resolved and vetted: it must be a real
+     * nested element and the CANONICAL one, because positions live on the
+     * canonical block's ownership rows; a draft or revision copy has its own
+     * stale row and renumbering it would misreport a move of the visible
+     * field.
+     */
+    private function blockFor(int $id, ?string $site): Entry {
+        $block = $this->find($id, $site);
+
+        if ($block->fieldId === null || $block->getOwnerId() === null) {
+            throw new ToolCallException(
+                "Entry {$id} is not a nested element; move_nested_entry only repositions blocks inside a Matrix field on their owner entry.",
+            );
+        }
+
+        if ($block->getIsDraft() || $block->getIsRevision()) {
+            $kind = $block->getIsDraft() ? 'draft' : 'revision';
+
+            throw new ToolCallException(
+                "Entry {$id} is a {$kind} of block {$block->getCanonicalId()}; positions belong to the canonical block. Call move_nested_entry with id {$block->getCanonicalId()}.",
+            );
+        }
+
+        return $block;
+    }
+
+    /**
+     * Draft mode targets a draft of the owner, live mode the owner itself.
+     * An owner that already IS a draft is reused as-is in both modes (a
+     * draft of a draft is illegal in Craft, and a "live" write into a draft
+     * owner is still pending by ownership), and the response's state key
+     * reports what actually happened.
+     */
+    private function target(Entry $owner, WriteMode $mode): Entry {
+        return $mode === WriteMode::Draft ? $this->draftOf($owner) : $owner;
+    }
+
+    private function draftOf(Entry $owner): Entry {
+        if ($owner->getIsDraft()) {
+            return $owner;
+        }
+
+        /** @var Entry */
+        return Craft::$app->getDrafts()->createDraft($owner, Craft::$app->getUser()->getId());
+    }
+
+    /**
+     * The Matrix field $handle names on the owner's layout. Pure lookup, so
+     * unknown handles can answer with the handles that WOULD work.
+     */
+    private function matrixField(?FieldLayout $layout, string $handle): Matrix {
+        $available = [];
+        foreach ($layout?->getCustomFields() ?? [] as $field) {
+            if ($field instanceof Matrix) {
+                $available[$field->handle] = $field;
+            }
+        }
+
+        if (isset($available[$handle])) {
+            return $available[$handle];
+        }
+
+        $handles = $available === [] ? '(none)' : implode(', ', array_keys($available));
+
+        throw new ToolCallException(
+            "Field '{$handle}' is not a Matrix field on this entry. Matrix fields available: {$handles}",
+        );
+    }
+
+    /**
+     * The field an existing block lives in. A CKEditor-nested entry has no
+     * positional meaning (its rendered order is markup-driven), so anything
+     * that is not a Matrix field refuses rather than renumbering rows the
+     * page never reads.
+     */
+    private function matrixFieldOf(Entry $block): Matrix {
+        try {
+            $field = $block->getField();
+        } catch (Throwable) {
+            $field = null;
+        }
+
+        if ($field === null) {
+            throw new ToolCallException("Block {$block->id} references a field that no longer exists; it cannot be repositioned.");
+        }
+
+        if (!$field instanceof Matrix) {
+            throw new ToolCallException(
+                "Block {$block->id} lives in field '{$field->handle}', which is not a Matrix field; only Matrix blocks have a position to move.",
+            );
+        }
+
+        return $field;
+    }
+
+    private function blockType(Matrix $field, string $handle): EntryType {
+        foreach ($field->getEntryTypes() as $entryType) {
+            if ($entryType->handle === $handle) {
+                return $entryType;
+            }
+        }
+
+        $handles = implode(', ', array_map(static fn (EntryType $type): string => (string) $type->handle, $field->getEntryTypes()));
+
+        throw new ToolCallException("Entry type '{$handle}' is not allowed in Matrix field '{$field->handle}'. Allowed types: {$handles}");
+    }
+
+    /**
+     * The block is saved LIVE even in draft mode: its pending-ness comes
+     * from being owned by the owner draft, which is exactly how the control
+     * panel models a block added inside a draft. Saving it as a draft
+     * element instead would make it its own canonical and expose it to
+     * Craft's canonical-owner cleanup sweeps.
+     *
+     * @return array<string, mixed>
+     */
+    private function blockAttributes(EntryType $entryType, Matrix $field, Entry $target, ?string $title): array {
+        $attributes = [
+            'type' => Entry::class,
+            'typeId' => $entryType->id,
+            'fieldId' => $field->id,
+            'ownerId' => $target->id,
+            'primaryOwnerId' => $target->id,
+            'siteId' => $target->siteId,
+        ];
+
+        if ($title !== null) {
+            $attributes['title'] = $title;
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * The 1-based position a block appended without an explicit position
+     * ends up in: the last slot. Counted from the target's own field value
+     * rather than echoing the stored sortOrder, which trashed and draft
+     * sibling rows inflate past the visible block count. Counts the query
+     * itself, never a clone: cloning a yii Component detaches the behavior
+     * that scopes the query to this owner at prepare time.
+     */
+    private function endPosition(Entry $target, Matrix $field): int {
+        $value = $target->getFieldValue($field->handle);
+        if (!$value instanceof ElementQueryInterface) {
+            throw new ToolCallException(
+                "Field '{$field->handle}' on entry {$target->id} did not return a block query; cannot report the block position.",
+            );
+        }
+
+        return (int) $value->status(null)->count();
+    }
+
+    /**
+     * A draft-mode write never touches what craft://entries/{section}/{slug}
+     * serves, so only a change to a non-draft target notifies subscribers.
+     */
+    private function notifyOwner(?RequestContext $context, Entry $target): void {
+        if ($target->getIsDraft()) {
+            return;
+        }
+
+        ResourceChangeNotifier::notifyEntry($context, (int) $target->getCanonicalId());
+    }
+
+    /**
+     * The standard write-response shape as far as it fits a nested write:
+     * the draft keys describe the OWNER draft (draftElementId is what
+     * publish_entry accepts), blockId/ownerId/position locate the block
+     * itself, and cpEditUrl deep-links the human to the target owner where
+     * the block is visible in context.
+     *
+     * @param Warning[] $warnings
+     * @return array<string, mixed>
+     */
+    private function blockResponse(string $action, int $blockId, Entry $target, int $position, array $warnings = []): array {
+        $isDraft = $target->getIsDraft();
+
+        return [
+            'action' => $action,
+            'blockId' => $blockId,
+            'ownerId' => (int) $target->getCanonicalId(),
+            'draftId' => $isDraft ? $target->draftId : null,
+            'draftElementId' => $isDraft ? (int) $target->id : null,
+            'state' => $isDraft ? WriteMode::Draft->value : WriteMode::Live->value,
+            'position' => $position,
+            'cpEditUrl' => $target->getCpEditUrl(),
+            'warnings' => array_map(static fn (Warning $warning): array => $warning->toArray(), $warnings),
+            'errors' => [],
+        ];
+    }
+}

--- a/src/tools/NestedEntryTools.php
+++ b/src/tools/NestedEntryTools.php
@@ -78,16 +78,32 @@ class NestedEntryTools {
             $matrix = $this->matrixField($ownerEntry->getFieldLayout(), $field);
             $entryType = $this->blockType($matrix, $type);
             $target = $this->target($ownerEntry, $writeMode);
+            // Only a draft this call opened is ours to clean up; an owner
+            // draft the caller passed in belongs to them and their earlier
+            // blocks live on it.
+            $opened = $target === $ownerEntry ? null : $target;
 
             $result = $this->writer->create($this->blockAttributes($entryType, $matrix, $target, $title), $payload, WriteMode::Live, $site);
             if ($result->isFailure()) {
+                $this->discard($opened, null);
+
                 return ['success' => false] + $result->toArray();
             }
 
             $blockId = (int) $result->elementId;
-            $taken = $position === null
-                ? $this->endPosition($target, $matrix)
-                : NestedPosition::move($target, $matrix, $blockId, $position);
+
+            try {
+                $taken = $position === null
+                    ? $this->endPosition($target, $matrix)
+                    : NestedPosition::move($target, $matrix, $blockId, $position);
+            } catch (Throwable $e) {
+                // The block saved but placing it did not: without this the call
+                // reports failure while the block sits on the target, so a retry
+                // adds a second copy.
+                $this->discard($opened, $blockId);
+
+                throw $e;
+            }
 
             $this->notifyOwner($context, $target);
 
@@ -198,6 +214,30 @@ class NestedEntryTools {
      */
     private function target(Entry $owner, WriteMode $mode): Entry {
         return $mode === WriteMode::Draft ? $this->draftOf($owner) : $owner;
+    }
+
+    /**
+     * Undo what this call created before it failed. Deleting the owner draft
+     * cascades to a block already attached to it, so the two cases never both
+     * apply; without either, a failed create leaves an empty draft in the
+     * review queue or a block a retry would duplicate.
+     */
+    private function discard(?Entry $openedDraft, ?int $blockId): void {
+        $elements = Craft::$app->getElements();
+
+        if ($openedDraft instanceof Entry) {
+            $elements->deleteElement($openedDraft, true);
+
+            return;
+        }
+
+        $block = $blockId === null
+            ? null
+            : Entry::find()->id($blockId)->drafts(null)->status(null)->one();
+
+        if ($block instanceof Entry) {
+            $elements->deleteElement($block, true);
+        }
     }
 
     private function draftOf(Entry $owner): Entry {

--- a/tests/Fixtures/CustomFieldBehaviorStub.php
+++ b/tests/Fixtures/CustomFieldBehaviorStub.php
@@ -4,20 +4,46 @@ declare(strict_types=1);
 
 namespace craft\behaviors;
 
+use yii\base\Behavior;
+
 /**
  * Minimal CustomFieldBehavior stub for unit tests that don't bootstrap the
  * full Craft application. The real class only exists as a template
  * (src/behaviors/CustomFieldBehavior.php.template) that Craft::autoload()
  * compiles into memory once Craft::$app is fully booted and installed; unit
- * tests never boot Craft, so the real class is never generated. They only
- * need the public static $fieldHandles map that
- * ConfigFreshness::patchHandles() writes to.
+ * tests never boot Craft, so the real class is never generated.
+ *
+ * ConfigFreshness::patchHandles() only needs the public static $fieldHandles
+ * map. Element construction (NestedPositionTest and friends build real
+ * Entry/GlobalSet instances) additionally needs the stub to be an attachable
+ * yii Behavior carrying the canSetProperties/hasMethods flags and magic
+ * field-value storage the real template declares, because Element::init()
+ * attaches and configures the 'customFields' behavior unconditionally.
  *
  * Only loaded if the real, Craft-generated class isn't available.
  */
 if (!class_exists('craft\\behaviors\\CustomFieldBehavior', false)) {
-    class CustomFieldBehavior {
+    class CustomFieldBehavior extends Behavior {
         /** @var array<string, bool> */
         public static array $fieldHandles = [];
+
+        public bool $canSetProperties = true;
+
+        public bool $hasMethods = false;
+
+        /** @var array<string, mixed> */
+        private array $values = [];
+
+        public function __get($name): mixed {
+            return $this->values[$name] ?? null;
+        }
+
+        public function __set($name, $value): void {
+            $this->values[$name] = $value;
+        }
+
+        public function __isset($name): bool {
+            return isset($this->values[$name]);
+        }
     }
 }

--- a/tests/Fixtures/Layouts.php
+++ b/tests/Fixtures/Layouts.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace stimmt\craft\Mcp\Tests\Fixtures;
 
 use Closure;
+use craft\fields\Matrix;
+use craft\models\EntryType;
 use craft\models\FieldLayout;
 use craft\models\FieldLayoutTab;
 use ReflectionObject;
@@ -27,6 +29,21 @@ final class Layouts {
         (new ReflectionObject($layout))->getProperty('_tabs')->setValue($layout, [$tab]);
 
         return $layout;
+    }
+
+    /**
+     * A real Matrix field whose private entry-type storage is set via
+     * reflection, bypassing only setEntryTypes() (which resolves every type
+     * through Craft::$app's entries service); type lookups by handle run
+     * unmocked.
+     *
+     * @param EntryType[] $entryTypes
+     */
+    public static function matrix(string $handle, array $entryTypes = [], ?int $id = null): Matrix {
+        $field = new Matrix(['handle' => $handle, 'id' => $id]);
+        (new ReflectionObject($field))->getProperty('_entryTypes')->setValue($field, $entryTypes);
+
+        return $field;
     }
 
     /**

--- a/tests/Unit/Elements/Refs/ContainersTest.php
+++ b/tests/Unit/Elements/Refs/ContainersTest.php
@@ -17,6 +17,70 @@ function upcaseRecurse(): Closure {
 }
 
 describe('Containers', function () {
+    // Block order cannot survive the wire: blocks are keyed by their numeric
+    // entry id, and JSON objects with integer-like keys are re-ordered
+    // ascending by most clients, so an agent would read a page's blocks in id
+    // order and, writing that payload back, silently reshuffle the field
+    // (Craft renumbers sortOrder from value order).
+    it('numbers blocks in field order on the way out', function () {
+        $blocks = [
+            480 => ['type' => 'text', 'fields' => ['body' => 'second in id, first on the page']],
+            475 => ['type' => 'text', 'fields' => ['body' => 'first in id, second on the page']],
+        ];
+
+        $out = (new Containers(upcaseRecurse()))->toKeys(new Matrix(), $blocks, new Context());
+
+        expect($out[480]['position'])->toBe(1)
+            ->and($out[475]['position'])->toBe(2);
+    });
+
+    it('restores the intended order on the way in, whatever the key order', function () {
+        // Exactly what a JavaScript client hands back: keys ascending by id,
+        // positions still saying which one comes first.
+        $blocks = [
+            475 => ['type' => 'text', 'position' => 2, 'fields' => ['body' => 'b']],
+            480 => ['type' => 'text', 'position' => 1, 'fields' => ['body' => 'a']],
+        ];
+
+        $out = (new Containers(upcaseRecurse()))->toIds(new Matrix(), $blocks, new Context());
+
+        expect(array_keys($out))->toBe([480, 475]);
+    });
+
+    it('never passes position through to Craft', function () {
+        $blocks = [
+            475 => ['type' => 'text', 'position' => 2, 'fields' => ['body' => 'b']],
+            480 => ['type' => 'text', 'position' => 1, 'fields' => ['body' => 'a']],
+        ];
+
+        $out = (new Containers(upcaseRecurse()))->toIds(new Matrix(), $blocks, new Context());
+
+        expect($out[480])->not->toHaveKey('position')
+            ->and($out[475])->not->toHaveKey('position');
+    });
+
+    // Positions are advisory: a hand-written payload without them is saved in
+    // the order it was written, which is the documented behavior.
+    it('keeps the given order when positions are absent or partial', function () {
+        $blocks = [
+            'new2' => ['type' => 'text', 'fields' => ['body' => 'b']],
+            'new1' => ['type' => 'text', 'position' => 1, 'fields' => ['body' => 'a']],
+        ];
+
+        $out = (new Containers(upcaseRecurse()))->toIds(new Matrix(), $blocks, new Context());
+
+        expect(array_keys($out))->toBe(['new2', 'new1'])
+            ->and($out['new1'])->not->toHaveKey('position');
+    });
+
+    it('leaves a single container value untouched', function () {
+        $value = ['fields' => ['body' => 'x']];
+
+        $out = (new Containers(upcaseRecurse()))->toKeys(new ContentBlock(), $value, new Context());
+
+        expect($out)->not->toHaveKey('position');
+    });
+
     it('handles the three container field types', function () {
         $containers = new Containers(upcaseRecurse());
 

--- a/tests/Unit/Services/ToolRegistryTest.php
+++ b/tests/Unit/Services/ToolRegistryTest.php
@@ -14,3 +14,14 @@ it('sums by_source to total in getSummary()', function () {
     expect(array_sum($summary['by_source']))->toBe($summary['total'])
         ->and(array_sum($summary['by_category']))->toBe($summary['total']);
 });
+
+// The registry definitions are what list_mcp_tools serves and what the
+// scope/danger filters run on, so the nested tools must surface here as
+// dangerous content tools or they silently fall out of both.
+it('registers the nested-entry tools as dangerous content tools', function (string $name) {
+    $definition = Mcp::getToolRegistry()->getDefinition($name);
+
+    expect($definition)->not->toBeNull()
+        ->and($definition->category)->toBe('content')
+        ->and($definition->dangerous)->toBeTrue();
+})->with([['create_nested_entry'], ['move_nested_entry']]);

--- a/tests/Unit/Support/NestedPositionTest.php
+++ b/tests/Unit/Support/NestedPositionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../Fixtures/RealCraft.php';
+require_once __DIR__ . '/../../Fixtures/CustomFieldBehaviorStub.php';
+
+use craft\elements\Entry;
+use craft\elements\GlobalSet;
+use Mcp\Exception\ToolCallException;
+use stimmt\craft\Mcp\support\NestedPosition;
+
+describe('NestedPosition::reorder', function () {
+    it('moves a block to an earlier position and reports it', function () {
+        [$order, $taken] = NestedPosition::reorder([10, 20, 30, 40], 30, 2);
+
+        expect($order)->toBe([10, 30, 20, 40])
+            ->and($taken)->toBe(2);
+    });
+
+    it('moves a block to a later position', function () {
+        [$order, $taken] = NestedPosition::reorder([10, 20, 30, 40], 10, 3);
+
+        expect($order)->toBe([20, 30, 10, 40])
+            ->and($taken)->toBe(3);
+    });
+
+    it('moves a block to the front', function () {
+        [$order, $taken] = NestedPosition::reorder([10, 20, 30], 30, 1);
+
+        expect($order)->toBe([30, 10, 20])
+            ->and($taken)->toBe(1);
+    });
+
+    it('clamps a position past the end and reports the position actually taken', function () {
+        [$order, $taken] = NestedPosition::reorder([10, 20, 30], 10, 99);
+
+        expect($order)->toBe([20, 30, 10])
+            ->and($taken)->toBe(3);
+    });
+
+    it('keeps the order intact when the block already holds the position', function () {
+        [$order, $taken] = NestedPosition::reorder([10, 20, 30], 20, 2);
+
+        expect($order)->toBe([10, 20, 30])
+            ->and($taken)->toBe(2);
+    });
+
+    it('handles a single-block field', function () {
+        [$order, $taken] = NestedPosition::reorder([10], 10, 5);
+
+        expect($order)->toBe([10])
+            ->and($taken)->toBe(1);
+    });
+
+    it('rejects a position below one', function () {
+        NestedPosition::reorder([10, 20], 10, 0);
+    })->throws(ToolCallException::class, 'position');
+
+    it('rejects a block id that is not in the list', function () {
+        NestedPosition::reorder([10, 20], 99, 1);
+    })->throws(ToolCallException::class, '99');
+});
+
+describe('NestedPosition::capture', function () {
+    // Both null guards run behaviorally on real element instances; only the
+    // elements_owners row read itself needs a database and is pinned
+    // structurally below.
+    it('returns null for an element type that is never nested', function () {
+        expect(NestedPosition::capture(new GlobalSet(['siteId' => 1, 'id' => 3])))->toBeNull();
+    });
+
+    it('returns null for an entry that has no owner', function () {
+        expect(NestedPosition::capture(new Entry(['siteId' => 1, 'id' => 5])))->toBeNull();
+    });
+
+    // The row read must target the CANONICAL block's CURRENT row: a draft's
+    // own ownership row still carries the position from draft-creation time,
+    // so a block reordered after being drafted would publish back to its old
+    // spot if the draft's row were read instead. Reading the row needs a
+    // database, so the query's shape is pinned here; the round trip runs on a
+    // real install.
+    it('reads the canonical row from elements_owners, not the draft copy', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedPosition::class))->getFileName());
+
+        expect($source)->toContain('Table::ELEMENTS_OWNERS')
+            ->and($source)->toContain('getCanonicalId()')
+            ->and($source)->toContain('getOwnerId()');
+    });
+});
+
+describe('NestedPosition::move', function () {
+    // move() saves the owner through Craft's supported value path, which
+    // needs a booted application; the reorder arithmetic is covered
+    // behaviorally above, and the save contract is pinned here. The contract:
+    // the field value must be fetched with status(null) (core deletes any
+    // block missing from the value, so disabled siblings must ride along),
+    // reordered via setCachedResult + setFieldValue (which marks the field
+    // dirty so NestedElementManager::saveNestedElements() renumbers by value
+    // order inside its own transaction), and the owner saved through
+    // saveElement. Never write elements_owners directly.
+    it('reorders through the supported owner-save path, disabled blocks included', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedPosition::class))->getFileName());
+
+        $statusNull = strpos($source, '->status(null)->all()');
+        $cached = strpos($source, '->setCachedResult(');
+        $setValue = strpos($source, '->setFieldValue(');
+        $save = strpos($source, '->saveElement(');
+
+        expect($statusNull)->toBeInt()
+            ->and($cached)->toBeInt()
+            ->and($setValue)->toBeInt()
+            ->and($save)->toBeInt()
+            ->and($statusNull)->toBeLessThan($cached)
+            ->and($cached)->toBeLessThan($setValue)
+            ->and($setValue)->toBeLessThan($save)
+            ->and($source)->not->toContain('Db::update');
+    });
+
+    // Blocks are matched by canonical id, not element id: under a saved owner
+    // draft, an edited block is represented by a shed copy whose element id
+    // differs from the canonical block the caller named, and the copy's
+    // canonicalId is the only stable link between them.
+    it('matches blocks by canonical id', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedPosition::class))->getFileName());
+
+        expect($source)->toContain('$block->getCanonicalId()');
+    });
+
+    it('names the owner and field when the block is not among the field blocks', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedPosition::class))->getFileName());
+
+        expect($source)->toContain('is not among the blocks of field');
+    });
+});

--- a/tests/Unit/Support/WriteParamsTest.php
+++ b/tests/Unit/Support/WriteParamsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../Fixtures/RealCraft.php';
+
+use Mcp\Exception\ToolCallException;
+use stimmt\craft\Mcp\elements\WriteMode;
+use stimmt\craft\Mcp\support\WriteParams;
+
+describe('WriteParams::fieldsPayload', function () {
+    it('returns an empty payload for a null fields parameter', function () {
+        expect(WriteParams::fieldsPayload(null))->toBe([]);
+    });
+
+    it('decodes a JSON object payload', function () {
+        expect(WriteParams::fieldsPayload('{"summary": "Hello"}'))->toBe(['summary' => 'Hello']);
+    });
+
+    it('rejects malformed JSON', function () {
+        WriteParams::fieldsPayload('{not json');
+    })->throws(ToolCallException::class, 'Invalid JSON');
+
+    it('rejects a JSON scalar, which is valid JSON but not a fields map', function () {
+        WriteParams::fieldsPayload('"just a string"');
+    })->throws(ToolCallException::class, 'Invalid JSON');
+});
+
+describe('WriteParams::mode', function () {
+    it('resolves an explicit mode case-insensitively', function (string $given, WriteMode $expected) {
+        expect(WriteParams::mode($given))->toBe($expected);
+    })->with([
+        ['draft', WriteMode::Draft],
+        ['LIVE', WriteMode::Live],
+        ['Draft', WriteMode::Draft],
+    ]);
+
+    it('rejects an unknown mode naming the valid ones', function () {
+        WriteParams::mode('bogus');
+    })->throws(ToolCallException::class, 'draft or live');
+
+    it('falls back to the entryWriteMode setting default when no mode is given', function () {
+        expect(WriteParams::mode(null))->toBe(WriteMode::Draft);
+    });
+});

--- a/tests/Unit/Tools/AuthorizationWiringTest.php
+++ b/tests/Unit/Tools/AuthorizationWiringTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use stimmt\craft\Mcp\tools\EntryTools;
 use stimmt\craft\Mcp\tools\EntryWorkflowTools;
+use stimmt\craft\Mcp\tools\NestedEntryTools;
 
 // Every entry-write tool must consult the acting-user guard before writing,
 // so content-scope HTTP tokens inherit the linked user's real CP permissions
@@ -28,4 +29,6 @@ it('guards every entry-write tool with the acting-user authorization', function 
     // The canonical-id publish path applies drafts[0]; the guard must check
     // that draft object itself (peer-draft permissions), not only the canonical.
     [EntryWorkflowTools::class, 'publishCanonical', 'assertCanPublish'],
+    [NestedEntryTools::class, 'createNestedEntry', 'assertCanSave'],
+    [NestedEntryTools::class, 'moveNestedEntry', 'assertCanSave'],
 ]);

--- a/tests/Unit/Tools/EntryToolsTest.php
+++ b/tests/Unit/Tools/EntryToolsTest.php
@@ -2,10 +2,19 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../../Fixtures/RealCraft.php';
+require_once __DIR__ . '/../../Fixtures/CustomFieldBehaviorStub.php';
+
+use craft\elements\Entry;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
+use Mcp\Exception\ToolCallException;
 use Mcp\Schema\ToolAnnotations;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\elements\Reader;
+use stimmt\craft\Mcp\elements\refs\Translator;
+use stimmt\craft\Mcp\elements\Writer;
+use stimmt\craft\Mcp\Tests\Fixtures\Layouts;
 use stimmt\craft\Mcp\tools\EntryTools;
 
 describe('EntryTools structure', function () {
@@ -119,6 +128,91 @@ describe('get_entry lookups', function () {
         $source = (string) file_get_contents((new ReflectionClass(EntryTools::class))->getFileName());
 
         expect($source)->toContain('revisions(null)');
+    });
+});
+
+describe('update_entry conflict detection', function () {
+    // The comparison helper runs behaviorally on constructed entries; only
+    // the full update round trip needs a booted application. The contract:
+    // expectedDateUpdated omitted means unchecked (nothing breaks for
+    // existing callers), a matching instant passes regardless of timezone
+    // formatting, and a mismatch throws naming both values so the caller
+    // re-reads instead of silently overwriting (#36).
+    beforeEach(function () {
+        $translator = Translator::withDefaults(Layouts::keysWith());
+        $this->assert = function (?DateTime $current, ?string $expected) use ($translator): void {
+            (new ReflectionMethod(EntryTools::class, 'assertUnchanged'))->invoke(
+                new EntryTools(new Reader($translator), new Writer($translator)),
+                new Entry(['siteId' => 1, 'id' => 7, 'dateUpdated' => $current]),
+                $expected,
+            );
+        };
+    });
+
+    it('accepts the expectedDateUpdated parameter', function () {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(EntryTools::class, 'updateEntry'))->getParameters(),
+        );
+
+        expect($params)->toContain('expectedDateUpdated');
+    });
+
+    it('is a no-op when expectedDateUpdated is omitted', function () {
+        ($this->assert)(new DateTime('2026-08-12 10:00:00'), null);
+
+        expect(true)->toBeTrue();
+    });
+
+    it('passes when the timestamps name the same instant', function () {
+        ($this->assert)(new DateTime('2026-08-12 10:00:00'), '2026-08-12 10:00:00');
+
+        expect(true)->toBeTrue();
+    });
+
+    it('passes when the same instant is written in another timezone', function () {
+        ($this->assert)(new DateTime('2026-08-12 10:00:00', new DateTimeZone('UTC')), '2026-08-12T12:00:00+02:00');
+
+        expect(true)->toBeTrue();
+    });
+
+    it('rejects a stale snapshot naming both values', function () {
+        try {
+            ($this->assert)(new DateTime('2026-08-12 10:00:00'), '2026-08-11 09:30:00');
+        } catch (ToolCallException $e) {
+            expect($e->getMessage())->toContain('changed since you read it')
+                ->toContain('2026-08-12 10:00:00')
+                ->toContain('2026-08-11 09:30:00')
+                ->toContain('get_entry');
+
+            return;
+        }
+
+        $this->fail('Expected a ToolCallException for a stale snapshot');
+    });
+
+    it('rejects an unparsable expectedDateUpdated', function () {
+        ($this->assert)(new DateTime('2026-08-12 10:00:00'), 'not a date');
+    })->throws(ToolCallException::class, 'expectedDateUpdated');
+
+    // The write path itself needs a booted application; this pins that the
+    // precondition actually guards updateEntry (behavior of the comparison
+    // is covered above).
+    it('checks the precondition inside updateEntry before writing', function () {
+        $reflection = new ReflectionMethod(EntryTools::class, 'updateEntry');
+        $file = (string) file_get_contents($reflection->getFileName());
+        $body = implode("\n", array_slice(
+            explode("\n", $file),
+            $reflection->getStartLine() - 1,
+            $reflection->getEndLine() - $reflection->getStartLine() + 1,
+        ));
+
+        $check = strpos($body, '$this->assertUnchanged($entry, $expectedDateUpdated)');
+        $write = strpos($body, '$this->writer->update(');
+
+        expect($check)->toBeInt()
+            ->and($write)->toBeInt()
+            ->and($check)->toBeLessThan($write);
     });
 });
 

--- a/tests/Unit/Tools/EntryWorkflowToolsTest.php
+++ b/tests/Unit/Tools/EntryWorkflowToolsTest.php
@@ -33,6 +33,38 @@ describe('EntryWorkflowTools structure', function () {
     });
 });
 
+describe('publish_entry block ordering', function () {
+    // Applying a draft of a single nested block silently moved it to the end
+    // of its Matrix field: applyDraft clones the draft with draftId nulled,
+    // so NestedElementTrait::saveOwnership() skips its sortOrder recovery
+    // lookup and falls through to max+1. The fix presets the canonical's
+    // current position on the draft BEFORE the apply, because saveOwnership
+    // checks isset(sortOrder) before either fallback and the preset value is
+    // then written inside the apply transaction. NestedPosition::capture's
+    // guard behavior is covered in NestedPositionTest; this pins the preset
+    // and its position relative to the apply call, which needs a real
+    // install to run.
+    it('presets the captured sort order on the draft before applying it', function () {
+        $reflection = new ReflectionMethod(EntryWorkflowTools::class, 'applyDraft');
+        $file = (string) file_get_contents($reflection->getFileName());
+        $body = implode("\n", array_slice(
+            explode("\n", $file),
+            $reflection->getStartLine() - 1,
+            $reflection->getEndLine() - $reflection->getStartLine() + 1,
+        ));
+
+        $capture = strpos($body, 'NestedPosition::capture($draft)');
+        $preset = strpos($body, '$draft->setSortOrder(');
+        $apply = strpos($body, '->applyDraft($draft)');
+
+        expect($capture)->toBeInt()
+            ->and($preset)->toBeInt()
+            ->and($apply)->toBeInt()
+            ->and($capture)->toBeLessThan($preset)
+            ->and($preset)->toBeLessThan($apply);
+    });
+});
+
 describe('publish_entry resource notification', function () {
     // publish_entry is the true canonical-change moment for the default
     // draft-first flow: applyDraft() merges the draft into the canonical

--- a/tests/Unit/Tools/NestedEntryToolsTest.php
+++ b/tests/Unit/Tools/NestedEntryToolsTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../Fixtures/RealCraft.php';
+require_once __DIR__ . '/../../Fixtures/CustomFieldBehaviorStub.php';
+
+use craft\fieldlayoutelements\CustomField;
+use craft\fields\Entries;
+use craft\models\EntryType;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
+use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\elements\refs\Translator;
+use stimmt\craft\Mcp\elements\Writer;
+use stimmt\craft\Mcp\enums\ToolCategory;
+use stimmt\craft\Mcp\Tests\Fixtures\Layouts;
+use stimmt\craft\Mcp\tools\NestedEntryTools;
+
+function nestedEntryTools(): NestedEntryTools {
+    return new NestedEntryTools(new Writer(Translator::withDefaults(Layouts::keysWith())));
+}
+
+describe('NestedEntryTools structure', function () {
+    it('exposes the two nested tools, both dangerous content tools', function (string $method, string $name) {
+        $reflection = new ReflectionMethod(NestedEntryTools::class, $method);
+        $meta = $reflection->getAttributes(McpToolMeta::class)[0]->newInstance();
+
+        expect($reflection->getAttributes(McpTool::class)[0]->newInstance()->name)->toBe($name)
+            ->and($meta->dangerous)->toBeTrue()
+            ->and($meta->category)->toBe(ToolCategory::CONTENT);
+    })->with([
+        ['createNestedEntry', 'create_nested_entry'],
+        ['moveNestedEntry', 'move_nested_entry'],
+    ]);
+
+    it('marks both tools destructive for MCP clients', function (string $method) {
+        $tool = (new ReflectionMethod(NestedEntryTools::class, $method))
+            ->getAttributes(McpTool::class)[0]->newInstance();
+
+        expect($tool->annotations?->destructiveHint)->toBeTrue();
+    })->with([['createNestedEntry'], ['moveNestedEntry']]);
+
+    it('accepts the documented parameters', function (string $method, array $expected) {
+        $params = array_map(
+            fn (ReflectionParameter $p): string => $p->getName(),
+            (new ReflectionMethod(NestedEntryTools::class, $method))->getParameters(),
+        );
+
+        expect($params)->toContain(...$expected);
+    })->with([
+        ['createNestedEntry', ['owner', 'field', 'type', 'title', 'fields', 'site', 'mode', 'position']],
+        ['moveNestedEntry', ['id', 'position', 'site', 'mode']],
+    ]);
+});
+
+describe('input hygiene before any lookup', function () {
+    // These guards run before the first Craft::$app access, so they execute
+    // behaviorally without a booted application: the deeper rejection paths
+    // (revision owners, draft block ids, non-Matrix fields) need element
+    // queries and are covered structurally below.
+    it('rejects a position below one on create', function () {
+        nestedEntryTools()->createNestedEntry(owner: 1, field: 'contentBuilder', type: 'text', position: 0);
+    })->throws(ToolCallException::class, 'position');
+
+    it('rejects a position below one on move', function () {
+        nestedEntryTools()->moveNestedEntry(id: 1, position: -3);
+    })->throws(ToolCallException::class, 'position');
+
+    it('rejects an unknown mode on create', function () {
+        nestedEntryTools()->createNestedEntry(owner: 1, field: 'contentBuilder', type: 'text', mode: 'bogus');
+    })->throws(ToolCallException::class, 'draft or live');
+
+    it('rejects an unknown mode on move', function () {
+        nestedEntryTools()->moveNestedEntry(id: 1, position: 1, mode: 'bogus');
+    })->throws(ToolCallException::class, 'draft or live');
+
+    it('rejects malformed fields JSON on create', function () {
+        nestedEntryTools()->createNestedEntry(owner: 1, field: 'contentBuilder', type: 'text', fields: '{oops');
+    })->throws(ToolCallException::class, 'Invalid JSON');
+});
+
+describe('Matrix field resolution', function () {
+    beforeEach(function () {
+        $this->layout = Layouts::with([
+            new CustomField(Layouts::matrix('contentBuilder', [], 12)),
+            new CustomField(new Entries(['handle' => 'related'])),
+        ]);
+        $this->resolve = fn (string $handle) => (new ReflectionMethod(NestedEntryTools::class, 'matrixField'))
+            ->invoke(nestedEntryTools(), $this->layout, $handle);
+    });
+
+    it('resolves a Matrix field by handle from the owner layout', function () {
+        expect(($this->resolve)('contentBuilder')->handle)->toBe('contentBuilder');
+    });
+
+    it('lists the available Matrix handles for an unknown handle', function () {
+        try {
+            ($this->resolve)('nope');
+        } catch (ToolCallException $e) {
+            expect($e->getMessage())->toContain('contentBuilder')->toContain('nope');
+
+            return;
+        }
+
+        $this->fail('Expected a ToolCallException for an unknown field handle');
+    });
+
+    it('rejects a handle that exists but is not a Matrix field', function () {
+        try {
+            ($this->resolve)('related');
+        } catch (ToolCallException $e) {
+            expect($e->getMessage())->toContain('related')->toContain('contentBuilder');
+
+            return;
+        }
+
+        $this->fail('Expected a ToolCallException for a non-Matrix field handle');
+    });
+});
+
+describe('block type resolution', function () {
+    beforeEach(function () {
+        $this->matrix = Layouts::matrix('contentBuilder', [
+            new EntryType(['handle' => 'text', 'id' => 1]),
+            new EntryType(['handle' => 'quote', 'id' => 2]),
+        ], 12);
+        $this->resolve = fn (string $handle) => (new ReflectionMethod(NestedEntryTools::class, 'blockType'))
+            ->invoke(nestedEntryTools(), $this->matrix, $handle);
+    });
+
+    it('resolves an entry type by handle within the field', function () {
+        expect(($this->resolve)('quote')->handle)->toBe('quote');
+    });
+
+    it('lists the allowed type handles for an unknown type', function () {
+        try {
+            ($this->resolve)('pullquote');
+        } catch (ToolCallException $e) {
+            expect($e->getMessage())->toContain('text')->toContain('quote')->toContain('pullquote');
+
+            return;
+        }
+
+        $this->fail('Expected a ToolCallException for an unknown entry type handle');
+    });
+});
+
+describe('owner-draft model', function () {
+    // The block must never be attached to the canonical owner as a pending
+    // draft: Craft's owner-save cleanup (NestedElementManager::
+    // deleteOtherNestedElements) hard-deletes unpublished draft blocks whose
+    // primary owner is the canonical, so any human CP edit of the owner would
+    // silently destroy the agent's pending block. The pending block therefore
+    // lives on a draft OF THE OWNER, saved live, exactly like a control panel
+    // edit. Exercising the save needs a booted application (the acceptance
+    // path runs on a real install); these pin the model's load-bearing
+    // choices at the source level.
+    it('attaches the block to the resolved target owner and saves it live', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect($source)->toContain("'ownerId' => \$target->id")
+            ->and($source)->toContain("'primaryOwnerId' => \$target->id")
+            ->and($source)->toContain('WriteMode::Live, $site');
+    });
+
+    it('reuses an owner that already is a draft instead of drafting a draft', function () {
+        $reflection = new ReflectionMethod(NestedEntryTools::class, 'draftOf');
+        $file = (string) file_get_contents($reflection->getFileName());
+        $body = implode("\n", array_slice(
+            explode("\n", $file),
+            $reflection->getStartLine() - 1,
+            $reflection->getEndLine() - $reflection->getStartLine() + 1,
+        ));
+
+        expect($body)->toContain('getIsDraft()')
+            ->and($body)->toContain('createDraft(');
+    });
+
+    it('authorizes against the owner canonical, not the draft', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect(substr_count($source, 'Authorization::assertCanSave($ownerEntry->getCanonical())'))->toBe(2);
+    });
+
+    it('rejects revision owners and draft or revision block ids with named errors', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect($source)->toContain('is a revision')
+            ->and($source)->toContain('positions belong to the canonical block');
+    });
+
+    it('rejects blocks whose field is not a Matrix field', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect($source)->toContain('instanceof Matrix')
+            ->and($source)->toContain('not a Matrix field');
+    });
+
+    it('places blocks through NestedPosition::move, never raw ownership writes', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect($source)->toContain('NestedPosition::move(')
+            ->and($source)->not->toContain('Db::update');
+    });
+
+    // Cloning a yii Component detaches its behaviors, and the field query's
+    // owner scoping IS a behavior applied at prepare time (Component::
+    // __clone), so a cloned query would count blocks across every owner of
+    // the field instead of this one.
+    it('never clones the owner-scoped field query', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect($source)->not->toContain('clone ');
+    });
+
+    it('notifies entry resource subscribers only when the canonical owner changed', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect($source)->toContain('getIsDraft()')
+            ->and(substr_count($source, 'ResourceChangeNotifier::notifyEntry('))->toBe(1);
+    });
+
+    it('returns the owner draft identifiers publish_entry accepts, plus block, state, and position', function () {
+        $source = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        foreach (["'blockId'", "'ownerId'", "'draftId'", "'draftElementId'", "'state'", "'position'", "'cpEditUrl'", "'warnings'"] as $key) {
+            expect($source)->toContain($key);
+        }
+    });
+});

--- a/tests/Unit/Tools/NestedEntryToolsTest.php
+++ b/tests/Unit/Tools/NestedEntryToolsTest.php
@@ -164,6 +164,45 @@ describe('owner-draft model', function () {
             ->and($source)->toContain('WriteMode::Live, $site');
     });
 
+    // A create that fails after opening a draft, or after saving the block but
+    // before placing it, must not leave either behind: a stranded empty draft
+    // clutters the human review queue, and a surviving block turns a reported
+    // failure into a duplicate on retry. Both cleanups need a booted
+    // application to exercise, so the call sites are pinned here and the
+    // helper's own branch logic is asserted below.
+    it('cleans up an opened draft or a saved block when a create fails', function () {
+        $method = new ReflectionMethod(NestedEntryTools::class, 'createNestedEntry');
+        $file = (string) file_get_contents($method->getFileName());
+        $body = implode("\n", array_slice(
+            explode("\n", $file),
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1,
+        ));
+
+        expect($body)->toContain('$this->discard($opened, null)')
+            ->and($body)->toContain('$this->discard($opened, $blockId)')
+            ->and($body)->toContain('catch (Throwable $e)');
+    });
+
+    it('only discards a draft this call opened, never one the caller passed in', function () {
+        $file = (string) file_get_contents((new ReflectionClass(NestedEntryTools::class))->getFileName());
+
+        expect($file)->toContain('$opened = $target === $ownerEntry ? null : $target;');
+
+        $method = new ReflectionMethod(NestedEntryTools::class, 'discard');
+        $body = implode("\n", array_slice(
+            explode("\n", $file),
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1,
+        ));
+
+        // Draft first and returning: deleting it cascades the block, so the
+        // block branch must not also run.
+        expect($body)->toContain('deleteElement($openedDraft, true)')
+            ->and($body)->toContain('return;')
+            ->and($body)->toContain('deleteElement($block, true)');
+    });
+
     it('reuses an owner that already is a draft instead of drafting a draft', function () {
         $reflection = new ReflectionMethod(NestedEntryTools::class, 'draftOf');
         $file = (string) file_get_contents($reflection->getFileName());


### PR DESCRIPTION
Closes #36, both halves: creating a block without resending its siblings, and detecting a stale read-modify-write instead of silently overwriting it.

## Tools
- **`create_nested_entry`**: add a block to a Matrix field by owner id, field handle and block type. Covers the case that had no workaround at all, the first block of a type that does not exist in the field yet. Optional `position` places it; the response reports the position actually taken.
- **`move_nested_entry`**: reposition a block by its own id, without resending the owner's field value.

Both are draft-first like every other write: the change lands on a draft **of the owner entry**, exactly as a control panel edit does. The response's `draftElementId` is the owner draft to review with `get_entry` and apply with `publish_entry`, and passing it back as `owner` stacks further blocks onto the same draft.

## Fixes
- **Publishing a block's draft no longer moves it to the end of its field.** Applying a draft of a lone nested element cannot recover its position and falls through to `max + 1`, so the path the docs recommend as the safe one silently reordered pages. The position is now set on the draft before the apply, inside the apply's own transaction.
- **`update_entry` accepts an optional `expectedDateUpdated`**, the `dateUpdated` string `get_entry` already returns. When the entry changed since that read, the write fails naming both timestamps instead of overwriting the newer content. Omitting it keeps the previous behavior.
- **Matrix block order now travels in an explicit `position`.** Blocks are keyed by their numeric entry id, and a JSON object with integer-like keys is re-ordered ascending by most clients (JavaScript does it by specification), so a payload reached agents in id order rather than page order. Since Craft renumbers `sortOrder` from the order of the value it is handed, reading an entry and writing it back unchanged could silently reshuffle its blocks. Reads number the blocks in field order, writes sort by those numbers when every block carries one, and the key is stripped before Craft sees it. Found by testing through a real client rather than in-process.

## Notes on the approach
- No Craft core tables are written. Reordering sets the owner's field value (including disabled blocks, whose omission would delete them) and saves the owner, so `NestedElementManager::saveNestedElements()` renumbers, tracks changes and invalidates caches itself. The only direct table access is a read of the current position.
- A block created in draft mode is owned by the owner draft, never the canonical. Craft's `deleteOtherNestedElements()` sweep hard-deletes unpublished draft blocks attached to a canonical owner, so that model would have let any unrelated control panel edit destroy pending work.
- A create that fails after opening a draft or saving the block deletes whichever it created, so a retry cannot duplicate a block or leave empty drafts in the review queue.

## Verify
`composer ci` (585 passing). Not yet exercised against a booted Craft install: create-with-position then publish, move-in-draft then publish, and a concurrent owner apply are the three scenarios worth running on the dev install before release.
