### PR TITLE
feat: one output layer for tool results, and stop sending every payload twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Text output for tool payloads: `run_query`, `get_table_counts`, and `count_entries` accept `output="text"` and return the same data laid out for a person (uniform rows as an aligned table, key-value data and breakdowns as aligned blocks, nesting indented), falling back to pretty JSON for anything that will not lay out cleanly. A tool opts in purely by declaring the parameter in its signature, and the rendering happens centrally, so no tool carries formatting code of its own
+- `colorOutput` config setting: whether human-readable output carries ANSI colour. Off by default, because escape sequences reach an AI client as literal noise it pays tokens for
+
+### Changed
+- `read_logs` with `output="text"` is no longer coloured unconditionally; its layout is unchanged and `colorOutput` restores the colours. Colour is now decided in exactly one place instead of per formatter
+
+### Fixed
+- Every tool payload is sent once instead of twice. The SDK serialized array returns into both `content` and `structuredContent`, doubling the wire and token cost of every call; no tool declares an output schema, so the duplicate carried nothing a client could use
+
 ## [1.4.0-beta.12] - 2026-08-06
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,13 @@ return [
     // Turn off on installs that provision MCP clients their own way.
     // Default: true
     'showClientConfigSnippet' => true,
+
+    // Whether human-readable tool output (output="text") carries ANSI colour.
+    // Off by default: the usual consumer is an AI client, which receives the
+    // escape sequences as literal noise and pays tokens for them. Turn it on
+    // when a person reads this server's output in a terminal.
+    // Default: false
+    'colorOutput' => false,
 ];
 ```
 
@@ -151,6 +158,7 @@ return [
 | `disabledScopes` | `array` | `[]` | Since 1.4.0. Scope names (`readonly`, `content`, `full`) closed on this install for everyone, admin included: they cannot be minted, and existing tokens of a disabled scope stop authenticating (rejected exactly like an unknown token) until the scope is re-enabled, which restores them without recreation. Regenerating an existing token stays possible so it survives the closure |
 | `additionalInstructions` | `string` | `''` | Since 1.4.0. Text appended to the server instructions, on every transport (stdio and HTTP alike), after everything else the plugin adds |
 | `showClientConfigSnippet` | `bool` | `true` | Since 1.4.0. Whether the token-reveal screen (My Account -> MCP Tokens) shows the ready-to-paste Claude Desktop config block alongside the new token |
+| `colorOutput` | `bool` | `false` | Whether human-readable output (`output="text"`, including `read_logs`) carries ANSI colour. Off by default because escape sequences are noise to an AI client; see [Text Output](tools/README.md#text-output) |
 
 See the [HTTP Transport guide](http-transport.md) for enabling remote access, minting tokens, and scopes.
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -401,6 +401,41 @@ return [
 
 These patterns give AI assistants predictable structures to work with, making it easier for them to chain tool calls and report results to users.
 
+### Offering a Text View
+
+Return the array and stop there: the server sends it as the tool result's single content item, and
+there is no second copy to keep in sync.
+
+A tool can also offer the same payload laid out for a person to read. That is opt-in by signature,
+and needs no formatting code of its own: declare a `ResponseFormat $output` parameter and the
+shared renderer handles the rest.
+
+```php
+use Mcp\Capability\Attribute\Schema;
+use stimmt\craft\Mcp\enums\ResponseFormat;
+use stimmt\craft\Mcp\support\Presenter;
+
+#[McpTool(name: 'list_widgets', description: 'List widgets')]
+public function listWidgets(
+    ?string $status = null,
+    #[Schema(description: Presenter::OUTPUT_DESCRIPTION)]
+    ResponseFormat $output = ResponseFormat::STRUCTURED,
+): array {
+    return ['count' => count($widgets), 'widgets' => $widgets];
+}
+```
+
+The parameter is deliberately unused in the method body. Declaring it puts the enum in the tool's
+JSON schema, which is what advertises the text view to clients and what the server keys off; a tool
+that does not declare it always returns the structured payload. Uniform rows render as an aligned
+table, key-value data and breakdowns as aligned blocks, and anything that will not lay out cleanly
+falls back to pretty-printed JSON, so no payload shape can break the view.
+
+Return a `TextContent` (or a full `CallToolResult`) instead when your output is genuinely special
+and a generic layout would lose what makes it readable: it is passed through untouched. Never
+colour it yourself. Colour is one install-wide setting, applied centrally, because ANSI escapes are
+noise to an AI client.
+
 ## Security Best Practices
 
 MCP tools have direct access to your plugin's functionality, so security is important. Follow these guidelines:

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -183,4 +183,35 @@ All tools return consistent response structures that AI assistants can easily pa
 - **Operations** return `success: true` with their data. Failures are not a payload: the tool call
   itself fails, and the client receives an MCP tool error (`isError: true`) whose text is the reason
 
+Every payload crosses the wire exactly once, as the tool result's single `content` item. Tools do
+not declare an output schema, so no `structuredContent` copy is sent alongside it.
+
 See individual tool documentation for specific response formats and examples.
+
+## Text Output
+
+Some tools accept an `output` parameter and can lay their payload out for a person instead of
+returning JSON:
+
+| Value | Result |
+|-------|--------|
+| `structured` (default) | The JSON payload documented for that tool |
+| `text` | The same data as aligned text: uniform rows become a table, key-value data and breakdowns become aligned blocks, nesting is indented |
+
+```
+get_table_counts output="text"
+
+          label           count
+--------  --------------  -----
+elements  Total elements  1234
+entries   Entries         567
+```
+
+Nothing is lost in the text view: it is a rendering of the same payload, and anything that does not
+lay out cleanly falls back to pretty-printed JSON. Tools that do not list `output` in their
+parameter table always return the structured payload.
+
+Text output is plain by default. ANSI colour is a single install-wide setting (`colorOutput`, off by
+default) because escape sequences are noise to an AI client and cost tokens for nothing; turn it on
+when a person reads this server's output in a terminal. See the
+[Configuration Guide](../configuration.md).

--- a/docs/tools/content.md
+++ b/docs/tools/content.md
@@ -123,6 +123,7 @@ Count entries, optionally grouped: by attribute (`status`, `type`, `section`, `s
 | `createdAfter` | string | null | ISO date/datetime; only entries created on or after this |
 | `createdBefore` | string | null | ISO date/datetime; only entries created before this |
 | `groupBy` | string | null | An attribute (`status`, `type`, `section`, `site`, `author`), a date bucket (`granularity:dateAttribute`, e.g. `"month:dateUpdated"`), or a field handle. Omit for a plain total |
+| `output` | string | "structured" | "structured" for the JSON payload, "text" for an aligned breakdown table. See [Text Output](README.md#text-output) |
 
 **Examples:**
 
@@ -162,6 +163,21 @@ With `groupBy`, a `buckets` list is added, one entry per distinct value, sorted 
   ],
   "groupBy": "month:dateUpdated"
 }
+```
+
+The same breakdown with `output="text"`:
+
+```
+count_entries section="news" groupBy="month:dateUpdated" output="text"
+
+success: true
+total:   245
+buckets:
+  key      count
+  -------  -----
+  2023-12  18
+  2024-01  32
+groupBy: month:dateUpdated
 ```
 
 ```json

--- a/docs/tools/database.md
+++ b/docs/tools/database.md
@@ -117,7 +117,11 @@ The detailed view shows you everything you need to write effective queries: colu
 
 Get a quick overview of how much content exists in your Craft installation. This returns row counts for all core Craft tables, giving you a sense of the site's scale at a glance.
 
-**Parameters:** None
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `output` | string | "structured" | "structured" for the JSON payload, "text" for an aligned table. See [Text Output](README.md#text-output) |
 
 **Example:**
 
@@ -164,6 +168,7 @@ Execute read-only SQL queries against your database. Best suited for custom plug
 |------|------|---------|-------------|
 | `sql` | string | Required | The SQL SELECT query to execute |
 | `limit` | int | 100 | Maximum number of rows to return |
+| `output` | string | "structured" | "structured" for the JSON payload, "text" for an aligned table of rows. See [Text Output](README.md#text-output) |
 
 **Security restrictions:**
 
@@ -198,6 +203,21 @@ run_query sql="SELECT e.id, el.title, el.slug FROM craft_entries e JOIN craft_el
     { "id": 2, "title": "Second Entry" }
   ]
 }
+```
+
+**Text response:**
+
+```
+run_query sql="SELECT id, title FROM craft_entries LIMIT 2" output="text"
+
+success: true
+count:   2
+columns: id, title
+rows:
+  id  title
+  --  ------------
+  1   First Entry
+  2   Second Entry
 ```
 
 **Error response:**

--- a/docs/tools/system.md
+++ b/docs/tools/system.md
@@ -114,7 +114,7 @@ Search through recent log entries with filtering by severity level, log source, 
 | `level` | string | null | Filter by log level: "error", "warning", or "info" |
 | `source` | string | null | Filter by log source: "web", "console", "queue", or a plugin name |
 | `pattern` | string | null | Case-insensitive search pattern to filter log messages |
-| `output` | string | "structured" | Output format: "structured" (JSON) or "text" (human-readable with ANSI colors) |
+| `output` | string | "structured" | Output format: "structured" (JSON) or "text" (human-readable log lines) |
 
 **Examples:**
 
@@ -134,7 +134,7 @@ read_logs pattern="database" limit=20
 # Filter by log source
 read_logs source="web" level="error"
 
-# Get human-readable colored output
+# Get human-readable output
 read_logs output="text" limit=10
 ```
 
@@ -166,12 +166,17 @@ read_logs output="text" limit=10
 
 **Response (text):**
 
-When using `output="text"`, returns ANSI-colored human-readable output:
-- Timestamps appear dimmed
-- ERROR level appears in red
-- WARNING level appears in yellow
-- INFO level appears dimmed
-- Stack traces are indented and dimmed
+When using `output="text"`, returns one line per entry as
+`timestamp [LEVEL] category: message`, with any stack trace indented beneath it:
+
+```
+2026-01-07 10:30:00 [ERROR] app\Service: Something failed
+  #0 /var/www/src/Service.php(123): SomeClass->method()
+```
+
+The lines are plain text by default. Enabling the `colorOutput` setting dims the timestamp,
+category and stack trace, and colours the level (red for ERROR, yellow for WARNING). See
+[Text Output](README.md#text-output).
 
 ---
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -113,12 +113,20 @@ class Settings extends Model {
     public bool $showClientConfigSnippet = true;
 
     /**
+     * Whether human-readable tool output (`output=text`) carries ANSI colour.
+     * False by default: the usual consumer is a model, and escape sequences
+     * reach it as literal `[2m` noise that costs tokens and means nothing.
+     * Turn it on when a person reads this server's output in a terminal.
+     */
+    public bool $colorOutput = false;
+
+    /**
      * @return array<int, array<int|string, mixed>>
      */
     #[Override]
     public function defineRules(): array {
         return [
-            [['enabled', 'enableDangerousTools', 'httpTransport', 'showClientConfigSnippet'], 'boolean'],
+            [['enabled', 'enableDangerousTools', 'httpTransport', 'showClientConfigSnippet', 'colorOutput'], 'boolean'],
             [['disabledTools', 'disabledPrompts', 'disabledResources', 'allowedIps', 'scopedTokenPrivilegedTools'], 'each', 'rule' => ['string']],
             [['disabledScopes'], 'each', 'rule' => ['in', 'range' => array_column(Scope::cases(), 'value')]],
             [['logLevel'], 'in', 'range' => ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']],

--- a/src/services/McpServerFactory.php
+++ b/src/services/McpServerFactory.php
@@ -7,6 +7,7 @@ namespace stimmt\craft\Mcp\services;
 use Craft;
 use craft\elements\User;
 use Mcp\Capability\Registry;
+use Mcp\Capability\Registry\ReferenceHandler;
 use Mcp\Server;
 use Mcp\Server\Builder;
 use Mcp\Server\Session\SessionStoreInterface;
@@ -25,8 +26,11 @@ use stimmt\craft\Mcp\models\ResourceDefinition;
 use stimmt\craft\Mcp\models\ToolDefinition;
 use stimmt\craft\Mcp\support\EventDispatcher;
 use stimmt\craft\Mcp\support\FileLogger;
+use stimmt\craft\Mcp\support\Palette;
+use stimmt\craft\Mcp\support\Presenter;
 use stimmt\craft\Mcp\support\Psr11ContainerAdapter;
 use stimmt\craft\Mcp\support\Psr16CacheAdapter;
+use stimmt\craft\Mcp\support\Renderer;
 
 /**
  * Factory for creating MCP Server instances.
@@ -70,6 +74,7 @@ class McpServerFactory {
             ->setContainer($this->container)
             ->setRegistry($registry)
             ->setEventDispatcher($eventDispatcher)
+            ->setReferenceHandler($this->presenter())
             ->setPaginationLimit(Mcp::settings()->paginationLimit);
 
         if ($sessionStore !== null) {
@@ -89,6 +94,20 @@ class McpServerFactory {
         $this->filterResources($registry);
 
         return $server;
+    }
+
+    /**
+     * The output layer, decorating the SDK's own reference handler so every
+     * tool call passes through it: one payload on the wire instead of two, and
+     * central text rendering for tools that declare the output parameter.
+     * Built here rather than in the Builder default so the container stays the
+     * one this factory already configures.
+     */
+    private function presenter(): Presenter {
+        return new Presenter(
+            new ReferenceHandler($this->container),
+            new Renderer(Palette::fromSettings()),
+        );
     }
 
     /**

--- a/src/support/Ansi.php
+++ b/src/support/Ansi.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace stimmt\craft\Mcp\support;
 
 /**
- * ANSI terminal formatting helper.
+ * The escape sequences themselves, and nothing more.
  *
- * Provides consistent terminal styling across all MCP tools.
+ * Whether any of this is emitted is Palette's call, never this class's and
+ * never a tool's. Only what is actually used is kept here: an unused colour
+ * constant is a suggestion to reach past the palette.
  *
  * @author Max van Essen <support@stimmt.digital>
  */
@@ -15,17 +17,9 @@ final class Ansi {
     // Colors
     public const string RED = "\033[31m";
 
-    public const string GREEN = "\033[32m";
-
     public const string YELLOW = "\033[33m";
 
-    public const string BLUE = "\033[34m";
-
-    public const string MAGENTA = "\033[35m";
-
     public const string CYAN = "\033[36m";
-
-    public const string WHITE = "\033[37m";
 
     public const string GRAY = "\033[90m";
 
@@ -33,10 +27,6 @@ final class Ansi {
     public const string BOLD = "\033[1m";
 
     public const string DIM = "\033[2m";
-
-    public const string ITALIC = "\033[3m";
-
-    public const string UNDERLINE = "\033[4m";
 
     // Reset
     public const string RESET = "\033[0m";
@@ -56,38 +46,10 @@ final class Ansi {
     }
 
     /**
-     * Wrap text in bold style.
-     */
-    public static function bold(string $text): string {
-        return self::BOLD . $text . self::RESET;
-    }
-
-    /**
      * Wrap text in red color.
      */
     public static function red(string $text): string {
         return self::RED . $text . self::RESET;
-    }
-
-    /**
-     * Wrap text in green color.
-     */
-    public static function green(string $text): string {
-        return self::GREEN . $text . self::RESET;
-    }
-
-    /**
-     * Wrap text in yellow color.
-     */
-    public static function yellow(string $text): string {
-        return self::YELLOW . $text . self::RESET;
-    }
-
-    /**
-     * Wrap text in cyan color.
-     */
-    public static function cyan(string $text): string {
-        return self::CYAN . $text . self::RESET;
     }
 
     /**

--- a/src/support/LogFormatter.php
+++ b/src/support/LogFormatter.php
@@ -7,43 +7,52 @@ namespace stimmt\craft\Mcp\support;
 use Mcp\Schema\Content\TextContent;
 
 /**
- * Formats log entries as human-readable colored text.
+ * Formats log entries as human-readable text.
+ *
+ * Log lines are the one payload the shared Renderer cannot improve on: the
+ * level colouring, the timestamp/category/message ordering and the indented
+ * stack trace are what make a log readable, and a table of them would not be.
+ * So this stays its own formatter, and only borrows the Palette so that
+ * whether it colours is decided in the same single place as everything else.
  *
  * @author Max van Essen <support@stimmt.digital>
  */
-final class LogFormatter {
+final readonly class LogFormatter {
+    public function __construct(private Palette $palette) {
+    }
+
     /**
-     * Format log entries as colored text.
+     * Format log entries as text.
      *
      * @param LogEntry[] $entries
      */
-    public static function format(array $entries): TextContent {
+    public function format(array $entries): TextContent {
         if ($entries === []) {
             return new TextContent('No log entries found.');
         }
 
-        $lines = array_map(self::formatEntry(...), $entries);
+        $lines = array_map($this->formatEntry(...), $entries);
 
         return new TextContent(implode("\n\n", $lines));
     }
 
     /**
-     * Format a single log entry with ANSI colors.
+     * Format a single log entry.
      */
-    private static function formatEntry(LogEntry $entry): string {
+    private function formatEntry(LogEntry $entry): string {
         $level = strtoupper($entry->level);
-        $levelFormatted = self::colorizeLevel($level, $entry->level);
+        $levelFormatted = $this->colorizeLevel($level, $entry->level);
 
         $line = sprintf(
             '%s [%s] %s: %s',
-            Ansi::dim($entry->timestamp),
+            $this->palette->muted($entry->timestamp),
             $levelFormatted,
-            Ansi::gray($entry->category),
+            $this->palette->subtle($entry->category),
             $entry->message,
         );
 
         if ($entry->hasStackTrace()) {
-            $line .= self::formatStackTrace($entry->stackTrace);
+            $line .= $this->formatStackTrace($entry->stackTrace);
         }
 
         return $line;
@@ -52,11 +61,11 @@ final class LogFormatter {
     /**
      * Colorize log level based on severity.
      */
-    private static function colorizeLevel(string $display, string $level): string {
+    private function colorizeLevel(string $display, string $level): string {
         return match (strtolower($level)) {
-            'error' => Ansi::red($display),
-            'warning' => Ansi::yellow($display),
-            default => Ansi::dim($display),
+            'error' => $this->palette->error($display),
+            'warning' => $this->palette->warning($display),
+            default => $this->palette->muted($display),
         };
     }
 
@@ -65,9 +74,9 @@ final class LogFormatter {
      *
      * @param StackFrame[] $frames
      */
-    private static function formatStackTrace(array $frames): string {
+    private function formatStackTrace(array $frames): string {
         $lines = array_map(
-            static fn (StackFrame $frame): string => Ansi::dim(sprintf(
+            fn (StackFrame $frame): string => $this->palette->muted(sprintf(
                 '  #%d %s(%d): %s',
                 $frame->index,
                 $frame->file,

--- a/src/support/Palette.php
+++ b/src/support/Palette.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use stimmt\craft\Mcp\Mcp;
+
+/**
+ * The one place that decides whether tool output carries ANSI colour.
+ *
+ * ANSI escapes are worth their bytes in a human terminal and are pure noise to
+ * a model: they arrive at an agent client as literal `[2m` sequences that cost
+ * tokens and carry no meaning. The usual consumer of this server is a model,
+ * so colour is OFF by default and the site owner opts in with the `colorOutput`
+ * setting.
+ *
+ * Roles, not colours, are the public API: callers ask for a heading or a
+ * warning and never learn which escape backs it, so the mapping can change in
+ * one place. Ansi stays the escape vocabulary; this class stays the policy.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final readonly class Palette {
+    public function __construct(private bool $enabled = false) {
+    }
+
+    /**
+     * The install's configured policy. Only wiring code (the server factory,
+     * a tool assembling its own formatter) calls this; renderers take the
+     * palette they are given so they stay testable without Craft.
+     */
+    public static function fromSettings(): self {
+        return new self(Mcp::settings()->colorOutput);
+    }
+
+    public function enabled(): bool {
+        return $this->enabled;
+    }
+
+    /**
+     * Column headers and section titles.
+     */
+    public function heading(string $text): string {
+        return $this->paint(Ansi::BOLD, $text);
+    }
+
+    /**
+     * Keys in a key-value block.
+     */
+    public function key(string $text): string {
+        return $this->paint(Ansi::CYAN, $text);
+    }
+
+    /**
+     * Structural chrome and absent-value markers.
+     */
+    public function muted(string $text): string {
+        return $this->paint(Ansi::DIM, $text);
+    }
+
+    /**
+     * Secondary detail that should read as background.
+     */
+    public function subtle(string $text): string {
+        return $this->paint(Ansi::GRAY, $text);
+    }
+
+    public function error(string $text): string {
+        return $this->paint(Ansi::RED, $text);
+    }
+
+    public function warning(string $text): string {
+        return $this->paint(Ansi::YELLOW, $text);
+    }
+
+    private function paint(string $style, string $text): string {
+        if (!$this->enabled) {
+            return $text;
+        }
+
+        return $style . $text . Ansi::RESET;
+    }
+}

--- a/src/support/Presenter.php
+++ b/src/support/Presenter.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Mcp\Capability\Registry\ElementReference;
+use Mcp\Capability\Registry\ReferenceHandlerInterface;
+use Mcp\Capability\Registry\ToolReference;
+use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\Result\CallToolResult;
+use stimmt\craft\Mcp\enums\ResponseFormat;
+
+/**
+ * Decides what a tool call actually puts on the wire.
+ *
+ * Left to itself, the SDK sends every array payload twice: CallToolHandler
+ * calls extractStructuredContent() (which returns an array verbatim) and
+ * formatResult() (which JSON-encodes the same array), and CallToolResult
+ * serializes both `content` and `structuredContent`. No tool here declares an
+ * outputSchema, so the second copy buys a client nothing and costs it the
+ * whole payload again in tokens. That handler skips both calls when the
+ * reference handler already returned a CallToolResult, so building one here
+ * is the one interception point that fixes it for every tool at once, without
+ * a line of change in any tool.
+ *
+ * It also serves the text convention: a tool opts into human-readable output
+ * purely by declaring `output: ResponseFormat` in its signature, which puts
+ * the parameter in its JSON schema. This class does the rendering centrally
+ * and never guesses for a tool that did not declare it.
+ *
+ * The same reference handler serves prompts and resources, so anything that is
+ * not a tool passes straight through.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final readonly class Presenter implements ReferenceHandlerInterface {
+    /**
+     * The parameter a tool declares to offer a text view. One name, so the
+     * convention is discoverable from any tool's schema.
+     */
+    public const string OUTPUT_PARAM = 'output';
+
+    public function __construct(
+        private ReferenceHandlerInterface $handler,
+        private Renderer $renderer,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function handle(ElementReference $reference, array $arguments): mixed {
+        $result = $this->handler->handle($reference, $arguments);
+
+        if (!$reference instanceof ToolReference) {
+            return $result;
+        }
+
+        if ($result instanceof CallToolResult) {
+            return $result;
+        }
+
+        if (is_array($result) && $this->wantsText($reference, $arguments)) {
+            return new CallToolResult([new TextContent($this->renderer->render($result))]);
+        }
+
+        // formatResult() is the SDK's own content formatting (Content objects
+        // pass through, arrays become one JSON TextContent), so tools that
+        // already return TextContent keep their exact output. Only the
+        // structuredContent duplicate is dropped.
+        return new CallToolResult($reference->formatResult($result));
+    }
+
+    /**
+     * True only when the tool advertises the output parameter as a
+     * ResponseFormat and this call asked for text.
+     *
+     * @param array<string, mixed> $arguments
+     */
+    private function wantsText(ToolReference $reference, array $arguments): bool {
+        if (!$this->declaresOutput($reference)) {
+            return false;
+        }
+
+        $requested = $arguments[self::OUTPUT_PARAM] ?? null;
+        if ($requested instanceof ResponseFormat) {
+            return $requested === ResponseFormat::TEXT;
+        }
+
+        return is_string($requested) && ResponseFormat::tryFrom($requested) === ResponseFormat::TEXT;
+    }
+
+    /**
+     * The schema, not the argument bag, is what makes the opt-in explicit: a
+     * tool with its own unrelated `output` parameter (tinker's dump mode) is
+     * not opted in, because its schema advertises different values.
+     */
+    private function declaresOutput(ToolReference $reference): bool {
+        $declared = $reference->tool->inputSchema['properties'][self::OUTPUT_PARAM]['enum'] ?? null;
+        if (!is_array($declared)) {
+            return false;
+        }
+
+        return array_diff(array_column(ResponseFormat::cases(), 'value'), $declared) === [];
+    }
+}

--- a/src/support/Presenter.php
+++ b/src/support/Presenter.php
@@ -41,6 +41,12 @@ final readonly class Presenter implements ReferenceHandlerInterface {
      */
     public const string OUTPUT_PARAM = 'output';
 
+    /**
+     * The one description of the convention, so every opted-in tool advertises
+     * it identically in its schema.
+     */
+    public const string OUTPUT_DESCRIPTION = 'Response format: "structured" (default) returns the JSON payload, "text" returns the same data laid out for a person to read.';
+
     public function __construct(
         private ReferenceHandlerInterface $handler,
         private Renderer $renderer,

--- a/src/support/Renderer.php
+++ b/src/support/Renderer.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+namespace stimmt\craft\Mcp\support;
+
+use Throwable;
+
+/**
+ * Turns a tool's array payload into text a person can read.
+ *
+ * Tools return one of a handful of recurring shapes (see Response): a list of
+ * uniform rows, a flat key-value map, a count breakdown, and nesting of those.
+ * Each gets the layout that reads best (aligned table, aligned key-value block,
+ * indented sub-block) and everything else degrades to pretty JSON rather than
+ * throwing or silently dropping data: this view is a convenience, never the
+ * only copy of the payload.
+ *
+ * It never decides colour itself; Palette does, and this class only asks for
+ * roles. Widths are always measured on uncoloured text, so a coloured render
+ * lays out exactly like a plain one.
+ *
+ * @author Max van Essen <support@stimmt.digital>
+ */
+final readonly class Renderer {
+    /**
+     * Nesting past this reads worse indented than as JSON, and bounds the
+     * recursion on payloads that nest without limit (Matrix inside Matrix).
+     */
+    private const int MAX_DEPTH = 5;
+
+    private const string INDENT = '  ';
+
+    private const string GAP = '  ';
+
+    private const string NOTHING = '(empty)';
+
+    /**
+     * Longest a scalar list may be before it stops reading as one line.
+     */
+    private const int INLINE_LIMIT = 100;
+
+    public function __construct(private Palette $palette) {
+    }
+
+    /**
+     * @param array<mixed> $payload
+     */
+    public function render(array $payload): string {
+        try {
+            return $this->block($payload, 0);
+        } catch (Throwable) {
+            return $this->json($payload);
+        }
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function block(array $value, int $depth): string {
+        if ($value === []) {
+            return $this->palette->muted(self::NOTHING);
+        }
+
+        if ($depth > self::MAX_DEPTH) {
+            return $this->json($value);
+        }
+
+        $table = $this->table($value);
+        if ($table !== null) {
+            return $table;
+        }
+
+        if (array_is_list($value)) {
+            return $this->items($value, $depth);
+        }
+
+        return $this->map($value, $depth);
+    }
+
+    /**
+     * A list of uniform rows, or a map of them (where the map key becomes the
+     * unnamed first column), laid out as an aligned table. Null when the value
+     * is not row-shaped, so the caller can fall back to a block.
+     *
+     * Columns are the union of the rows' keys in first-seen order: a row that
+     * omits one leaves the cell blank instead of costing every other row its
+     * column.
+     *
+     * @param array<mixed> $value
+     */
+    private function table(array $value): ?string {
+        $rows = array_values($value);
+        if (!$this->areRows($rows)) {
+            return null;
+        }
+
+        /** @var array<int, array<string, scalar|null>> $rows */
+        $columns = array_values(array_unique(array_merge(...array_map(array_keys(...), $rows))));
+        $matrix = array_map(fn (array $row): array => $this->cells($row, $columns), $rows);
+
+        if (!array_is_list($value)) {
+            $columns = ['', ...$columns];
+            $matrix = array_map(
+                static fn (array $cells, int|string $key): array => [(string) $key, ...$cells],
+                $matrix,
+                array_keys($value),
+            );
+        }
+
+        return $this->rows(array_map(strval(...), $columns), $matrix);
+    }
+
+    /**
+     * Every row must be a non-empty keyed array of cell-able values; anything
+     * nested or multiline would break the alignment the table exists for.
+     *
+     * @param array<mixed> $rows
+     */
+    private function areRows(array $rows): bool {
+        if ($rows === []) {
+            return false;
+        }
+
+        $shaped = array_filter(
+            $rows,
+            fn (mixed $row): bool => is_array($row) && $row !== [] && !array_is_list($row) && $this->areCells($row),
+        );
+
+        return count($shaped) === count($rows);
+    }
+
+    /**
+     * @param array<mixed> $row
+     */
+    private function areCells(array $row): bool {
+        $cells = array_filter(
+            $row,
+            static fn (mixed $cell): bool => ($cell === null || is_scalar($cell)) && !str_contains((string) $cell, "\n"),
+        );
+
+        return count($cells) === count($row);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<int, string>   $columns
+     *
+     * @return array<int, string>
+     */
+    private function cells(array $row, array $columns): array {
+        return array_map(
+            fn (string $column): string => array_key_exists($column, $row) ? $this->scalar($row[$column]) : '',
+            $columns,
+        );
+    }
+
+    /**
+     * @param array<int, string>              $columns
+     * @param array<int, array<int, string>>  $matrix
+     */
+    private function rows(array $columns, array $matrix): string {
+        $widths = array_map(
+            static fn (string $header, int $index): int => max(
+                mb_strlen($header),
+                ...array_map(static fn (array $cells): int => mb_strlen($cells[$index]), $matrix),
+            ),
+            $columns,
+            array_keys($columns),
+        );
+
+        $rule = array_map(static fn (int $width): string => str_repeat('-', $width), $widths);
+        $body = array_map(fn (array $cells): string => $this->line($cells, $widths), $matrix);
+
+        return implode("\n", [
+            $this->palette->heading($this->line($columns, $widths)),
+            $this->palette->muted($this->line($rule, $widths)),
+            ...$body,
+        ]);
+    }
+
+    /**
+     * @param array<int, string> $cells
+     * @param array<int, int>    $widths
+     */
+    private function line(array $cells, array $widths): string {
+        return rtrim(implode(self::GAP, array_map($this->pad(...), $cells, $widths)));
+    }
+
+    private function pad(string $text, int $width): string {
+        return $text . str_repeat(' ', max(0, $width - mb_strlen($text)));
+    }
+
+    /**
+     * A keyed map as aligned `key: value` lines. Keys whose value needs its own
+     * block are excluded from the alignment, so one deep branch cannot push
+     * every scalar line off to the right.
+     *
+     * @param array<mixed> $value
+     */
+    private function map(array $value, int $depth): string {
+        $inline = array_filter($value, $this->isInline(...));
+        $width = $this->keyWidth($inline);
+
+        $lines = array_map(
+            fn (int|string $key): string => $this->entry((string) $key, $value[$key], $width, $depth),
+            array_keys($value),
+        );
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<mixed> $inline
+     */
+    private function keyWidth(array $inline): int {
+        if ($inline === []) {
+            return 0;
+        }
+
+        return max(array_map(mb_strlen(...), array_map(strval(...), array_keys($inline))));
+    }
+
+    private function entry(string $key, mixed $value, int $width, int $depth): string {
+        $label = $this->palette->key($key) . ':';
+
+        if (!$this->isInline($value)) {
+            return $label . "\n" . $this->indent($this->value($value, $depth + 1));
+        }
+
+        return $label . str_repeat(' ', $width - mb_strlen($key) + 1) . $this->inline($value);
+    }
+
+    /**
+     * A list that is neither table-shaped nor short enough to inline: one
+     * bulleted block per item, so multi-key items stay grouped.
+     *
+     * @param array<mixed> $list
+     */
+    private function items(array $list, int $depth): string {
+        $blocks = array_map(
+            fn (mixed $item): string => $this->bullet($this->value($item, $depth + 1)),
+            $list,
+        );
+
+        return implode("\n", $blocks);
+    }
+
+    private function bullet(string $text): string {
+        $lines = explode("\n", $text);
+        $first = array_shift($lines);
+        $rest = array_map(static fn (string $line): string => self::INDENT . $line, $lines);
+
+        return implode("\n", ['- ' . $first, ...$rest]);
+    }
+
+    private function value(mixed $value, int $depth): string {
+        if (is_array($value)) {
+            return $this->block($value, $depth);
+        }
+
+        return $this->scalar($value);
+    }
+
+    /**
+     * Whether a value fits on the same line as its key. Anything that is not
+     * an array renders to a single line unless it is a multiline string, which
+     * reads better as an indented block.
+     */
+    private function isInline(mixed $value): bool {
+        if (is_array($value)) {
+            return $value === [] || $this->isInlineList($value);
+        }
+
+        return !str_contains($this->scalar($value), "\n");
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function isInlineList(array $value): bool {
+        if (!array_is_list($value)) {
+            return false;
+        }
+
+        $scalars = array_filter(
+            $value,
+            static fn (mixed $item): bool => ($item === null || is_scalar($item))
+                && !str_contains((string) $item, "\n")
+                && !str_contains((string) $item, ','),
+        );
+
+        return count($scalars) === count($value) && mb_strlen($this->join($value)) <= self::INLINE_LIMIT;
+    }
+
+    private function inline(mixed $value): string {
+        if ($value === []) {
+            return $this->palette->muted(self::NOTHING);
+        }
+
+        if (is_array($value)) {
+            return $this->join($value);
+        }
+
+        return $this->scalar($value);
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function join(array $value): string {
+        return implode(', ', array_map($this->scalar(...), $value));
+    }
+
+    /**
+     * JSON scalar semantics, kept legible: an agent reading this must not have
+     * to guess whether a field was absent, null, or an empty string.
+     */
+    private function scalar(mixed $value): string {
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if ($value === '') {
+            return '""';
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        return $this->json($value, false);
+    }
+
+    private function indent(string $text): string {
+        $lines = array_map(
+            static fn (string $line): string => $line === '' ? $line : self::INDENT . $line,
+            explode("\n", $text),
+        );
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Last resort for anything the layouts above cannot represent. Partial
+     * output is deliberate: a value PHP cannot encode must not cost the caller
+     * the rest of the payload.
+     */
+    private function json(mixed $value, bool $pretty = true): string {
+        $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR;
+        $encoded = json_encode($value, $pretty ? $flags | JSON_PRETTY_PRINT : $flags);
+
+        return $encoded !== false ? $encoded : get_debug_type($value);
+    }
+}

--- a/src/tools/DatabaseTools.php
+++ b/src/tools/DatabaseTools.php
@@ -6,11 +6,14 @@ namespace stimmt\craft\Mcp\tools;
 
 use Craft;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
 use Mcp\Exception\ToolCallException;
 use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
 use stimmt\craft\Mcp\attributes\McpToolMeta;
+use stimmt\craft\Mcp\enums\ResponseFormat;
 use stimmt\craft\Mcp\enums\ToolCategory;
+use stimmt\craft\Mcp\support\Presenter;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
 use stimmt\craft\Mcp\support\SqlReadGuard;
@@ -133,7 +136,13 @@ class DatabaseTools {
         annotations: new ToolAnnotations(destructiveHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DATABASE, dangerous: true)]
-    public function runQuery(string $sql, int $limit = 100, ?RequestContext $context = null): array {
+    public function runQuery(
+        string $sql,
+        int $limit = 100,
+        #[Schema(description: Presenter::OUTPUT_DESCRIPTION)]
+        ResponseFormat $output = ResponseFormat::STRUCTURED,
+        ?RequestContext $context = null,
+    ): array {
         return SafeExecution::run(function () use ($sql, $limit, $context): array {
             $context?->getClientGateway()?->progress(0, 2, 'Executing SQL query...');
 
@@ -197,7 +206,11 @@ class DatabaseTools {
         annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::DATABASE, privileged: true)]
-    public function getTableCounts(?RequestContext $context = null): array {
+    public function getTableCounts(
+        #[Schema(description: Presenter::OUTPUT_DESCRIPTION)]
+        ResponseFormat $output = ResponseFormat::STRUCTURED,
+        ?RequestContext $context = null,
+    ): array {
         return SafeExecution::run(function (): array {
             $db = Craft::$app->getDb();
             $prefix = $db->tablePrefix;

--- a/src/tools/EntryTools.php
+++ b/src/tools/EntryTools.php
@@ -22,10 +22,12 @@ use stimmt\craft\Mcp\elements\schema\Describer;
 use stimmt\craft\Mcp\elements\schema\Meta;
 use stimmt\craft\Mcp\elements\WriteMode;
 use stimmt\craft\Mcp\elements\Writer;
+use stimmt\craft\Mcp\enums\ResponseFormat;
 use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\Mcp;
 use stimmt\craft\Mcp\support\Authorization;
 use stimmt\craft\Mcp\support\ElementModule;
+use stimmt\craft\Mcp\support\Presenter;
 use stimmt\craft\Mcp\support\ResourceChangeNotifier;
 use stimmt\craft\Mcp\support\Response;
 use stimmt\craft\Mcp\support\SafeExecution;
@@ -130,6 +132,8 @@ class EntryTools {
         ?string $createdAfter = null,
         ?string $createdBefore = null,
         ?string $groupBy = null,
+        #[Schema(description: Presenter::OUTPUT_DESCRIPTION)]
+        ResponseFormat $output = ResponseFormat::STRUCTURED,
         ?RequestContext $context = null,
     ): array {
         return SafeExecution::run(function () use ($section, $type, $status, $site, $search, $filters, $relatedTo, $author, $updatedAfter, $updatedBefore, $createdAfter, $createdBefore, $groupBy): array {

--- a/src/tools/SystemTools.php
+++ b/src/tools/SystemTools.php
@@ -19,6 +19,7 @@ use stimmt\craft\Mcp\enums\ToolCategory;
 use stimmt\craft\Mcp\support\LogEntry;
 use stimmt\craft\Mcp\support\LogFormatter;
 use stimmt\craft\Mcp\support\LogParser;
+use stimmt\craft\Mcp\support\Palette;
 use stimmt\craft\Mcp\support\SafeExecution;
 
 /**
@@ -73,7 +74,7 @@ class SystemTools {
      */
     #[McpTool(
         name: 'read_logs',
-        description: 'Read recent log entries from Craft CMS logs. Filter by source (web, console, queue, or plugin name), level (error, warning, info), pattern (case-insensitive search), and limit. Use output=text for human-readable colored output.',
+        description: 'Read recent log entries from Craft CMS logs. Filter by source (web, console, queue, or plugin name), level (error, warning, info), pattern (case-insensitive search), and limit. Use output=text for a human-readable view with indented stack traces.',
         annotations: new ToolAnnotations(readOnlyHint: true, idempotentHint: true),
     )]
     #[McpToolMeta(category: ToolCategory::SYSTEM, privileged: true)]
@@ -89,7 +90,7 @@ class SystemTools {
             $entries = $this->fetchLogEntries($limit, $level, $pattern, $source, $context);
 
             return match ($output) {
-                ResponseFormat::TEXT => LogFormatter::format($entries),
+                ResponseFormat::TEXT => (new LogFormatter(Palette::fromSettings()))->format($entries),
                 ResponseFormat::STRUCTURED => [
                     'count' => count($entries),
                     'entries' => array_map(static fn (LogEntry $e): array => $e->toArray(), $entries),

--- a/src/tools/SystemTools.php
+++ b/src/tools/SystemTools.php
@@ -10,6 +10,7 @@ use craft\helpers\FileHelper as CraftFileHelper;
 use craft\models\CategoryGroup;
 use craft\models\Section;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
 use Mcp\Schema\Content\TextContent;
 use Mcp\Schema\ToolAnnotations;
 use Mcp\Server\RequestContext;
@@ -20,6 +21,7 @@ use stimmt\craft\Mcp\support\LogEntry;
 use stimmt\craft\Mcp\support\LogFormatter;
 use stimmt\craft\Mcp\support\LogParser;
 use stimmt\craft\Mcp\support\Palette;
+use stimmt\craft\Mcp\support\Presenter;
 use stimmt\craft\Mcp\support\SafeExecution;
 
 /**
@@ -83,6 +85,7 @@ class SystemTools {
         ?string $level = null,
         ?string $pattern = null,
         ?string $source = null,
+        #[Schema(description: Presenter::OUTPUT_DESCRIPTION)]
         ResponseFormat $output = ResponseFormat::STRUCTURED,
         ?RequestContext $context = null,
     ): array|TextContent {

--- a/tests/Unit/Models/SettingsTest.php
+++ b/tests/Unit/Models/SettingsTest.php
@@ -84,3 +84,16 @@ describe('Settings showClientConfigSnippet', function () {
         expect($settings->validate(['showClientConfigSnippet']))->toBeTrue();
     });
 });
+
+describe('Settings colorOutput', function () {
+    it('defaults to false so a model client never pays for escape sequences', function () {
+        expect((new Settings())->colorOutput)->toBeFalse();
+    });
+
+    it('validates as boolean', function () {
+        $settings = new Settings();
+        $settings->colorOutput = true;
+
+        expect($settings->validate(['colorOutput']))->toBeTrue();
+    });
+});

--- a/tests/Unit/Services/ToolResultWireTest.php
+++ b/tests/Unit/Services/ToolResultWireTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/Fixtures/RealCraft.php';
+
+use Mcp\Capability\Registry;
+use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\CallToolRequest;
+use Mcp\Schema\Tool;
+use Mcp\Server\Handler\Request\CallToolHandler;
+use Mcp\Server\Session\InMemorySessionStore;
+use Mcp\Server\Session\Session;
+use stimmt\craft\Mcp\enums\ResponseFormat;
+use stimmt\craft\Mcp\services\McpServerFactory;
+use stimmt\craft\Mcp\support\Palette;
+use stimmt\craft\Mcp\support\Presenter;
+use stimmt\craft\Mcp\support\Renderer;
+
+/**
+ * McpServerFactory::create() needs a booted Craft app, so this drives the real
+ * SDK CallToolHandler with the same collaborators the factory hands it. It is
+ * the end-to-end proof that a tool payload now crosses the wire once: without
+ * the Presenter, CallToolHandler emits `content` AND `structuredContent` for
+ * every array return.
+ */
+function callTool(callable $handler, array $inputSchema, array $arguments, bool $present = true): array {
+    $registry = new Registry();
+    $registry->registerTool(
+        new Tool(name: 'demo', title: null, inputSchema: $inputSchema, description: null, annotations: null),
+        $handler,
+    );
+
+    $inner = new ReferenceHandler();
+    $reference = $present ? new Presenter($inner, new Renderer(new Palette(false))) : $inner;
+
+    $result = (new CallToolHandler($registry, $reference))->handle(
+        (new CallToolRequest('demo', $arguments))->withId(1),
+        new Session(new InMemorySessionStore()),
+    );
+
+    expect($result)->toBeInstanceOf(Response::class);
+
+    return json_decode(json_encode($result->result), true);
+}
+
+describe('tool result on the wire', function () {
+    it('sends an array payload twice without the presenter (the bug)', function () {
+        $wire = callTool(
+            static fn (): array => ['count' => 1, 'handle' => 'default'],
+            ['type' => 'object'],
+            [],
+            present: false,
+        );
+
+        expect($wire)->toHaveKey('structuredContent')
+            ->and($wire['structuredContent'])->toBe(['count' => 1, 'handle' => 'default'])
+            ->and(json_decode($wire['content'][0]['text'], true))->toBe(['count' => 1, 'handle' => 'default']);
+    });
+
+    it('sends it exactly once with the presenter installed', function () {
+        $wire = callTool(
+            static fn (): array => ['count' => 1, 'handle' => 'default'],
+            ['type' => 'object'],
+            [],
+        );
+
+        expect($wire)->not->toHaveKey('structuredContent')
+            ->and($wire['content'])->toHaveCount(1)
+            ->and(json_decode($wire['content'][0]['text'], true))->toBe(['count' => 1, 'handle' => 'default']);
+    });
+
+    it('renders text for a tool that declares the output parameter', function () {
+        $wire = callTool(
+            static fn (ResponseFormat $output = ResponseFormat::STRUCTURED): array => ['count' => 1, 'handle' => 'default'],
+            [
+                'type' => 'object',
+                'properties' => [
+                    'output' => ['type' => 'string', 'enum' => array_column(ResponseFormat::cases(), 'value')],
+                ],
+            ],
+            ['output' => 'text'],
+        );
+
+        expect($wire['content'][0]['text'])->toBe("count:  1\nhandle: default")
+            ->and($wire)->not->toHaveKey('structuredContent');
+    });
+});
+
+describe('McpServerFactory wiring', function () {
+    /**
+     * create() itself needs a booted Craft app, so this pins the collaborator
+     * it installs: the SDK's own reference handler, wrapped in the Presenter,
+     * with a palette read from the install's settings.
+     */
+    it('builds the presenter around the SDK reference handler', function () {
+        $presenter = (new ReflectionMethod(McpServerFactory::class, 'presenter'))
+            ->invoke(new McpServerFactory());
+
+        expect($presenter)->toBeInstanceOf(Presenter::class);
+
+        $inner = (new ReflectionProperty(Presenter::class, 'handler'))->getValue($presenter);
+
+        expect($inner)->toBeInstanceOf(ReferenceHandler::class);
+    });
+
+    it('passes the reference handler to the builder', function () {
+        $source = file_get_contents(dirname(__DIR__, 3) . '/src/services/McpServerFactory.php');
+
+        expect($source)->toContain('->setReferenceHandler($this->presenter())');
+    });
+});

--- a/tests/Unit/Services/ToolResultWireTest.php
+++ b/tests/Unit/Services/ToolResultWireTest.php
@@ -6,6 +6,7 @@ require_once dirname(__DIR__, 2) . '/Fixtures/RealCraft.php';
 
 use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\ReferenceHandler;
+use Mcp\Schema\Content\TextContent;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Request\CallToolRequest;
 use Mcp\Schema\Tool;
@@ -85,6 +86,21 @@ describe('tool result on the wire', function () {
 
         expect($wire['content'][0]['text'])->toBe("count:  1\nhandle: default")
             ->and($wire)->not->toHaveKey('structuredContent');
+    });
+});
+
+describe('tools that build their own content', function () {
+    /**
+     * tinker and read_logs (output=text) return a TextContent. Their wire
+     * payload is the regression baseline for this change: it must be exactly
+     * what the SDK sent before the presenter existed, byte for byte.
+     */
+    it('sends a TextContent return exactly as the SDK did', function () {
+        $handler = static fn (): TextContent => new TextContent("> \$x = 1\n= 1");
+        $schema = ['type' => 'object'];
+
+        expect(callTool($handler, $schema, []))
+            ->toBe(callTool($handler, $schema, [], present: false));
     });
 });
 

--- a/tests/Unit/Support/LogFormatterTest.php
+++ b/tests/Unit/Support/LogFormatterTest.php
@@ -5,7 +5,18 @@ declare(strict_types=1);
 use Mcp\Schema\Content\TextContent;
 use stimmt\craft\Mcp\support\LogEntry;
 use stimmt\craft\Mcp\support\LogFormatter;
+use stimmt\craft\Mcp\support\Palette;
 use stimmt\craft\Mcp\support\StackFrame;
+
+/**
+ * Colour on by default here: that is the output read_logs produced before the
+ * palette existed, and these assertions are the regression baseline for it.
+ *
+ * @param LogEntry[] $entries
+ */
+function formatLogs(array $entries, bool $color = true): TextContent {
+    return (new LogFormatter(new Palette($color)))->format($entries);
+}
 
 describe('LogFormatter', function () {
     describe('format()', function () {
@@ -21,13 +32,13 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             expect($result)->toBeInstanceOf(TextContent::class);
         });
 
         it('handles empty entries', function () {
-            $result = LogFormatter::format([]);
+            $result = formatLogs([]);
 
             expect($result)->toBeInstanceOf(TextContent::class)
                 ->and($result->text)->toBe('No log entries found.');
@@ -45,7 +56,7 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             expect($result->text)
                 ->toContain('2026-01-07 10:30:00')
@@ -74,7 +85,7 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             expect($result->text)
                 ->toContain('First')
@@ -94,7 +105,7 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             // Red ANSI code
             expect($result->text)->toContain("\033[31mERROR\033[0m");
@@ -112,7 +123,7 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             // Yellow ANSI code
             expect($result->text)->toContain("\033[33mWARNING\033[0m");
@@ -130,7 +141,7 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             // Dim ANSI code
             expect($result->text)->toContain("\033[2mINFO\033[0m");
@@ -152,7 +163,7 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             expect($result->text)
                 ->toContain('#0 /var/www/file.php(123): SomeClass->method()')
@@ -174,10 +185,51 @@ describe('LogFormatter', function () {
                 ),
             ];
 
-            $result = LogFormatter::format($entries);
+            $result = formatLogs($entries);
 
             // Stack trace should be on new line with indentation (wrapped in dim ANSI)
             expect($result->text)->toContain("\n\033[2m  #0");
         });
+    });
+});
+
+describe('LogFormatter without colour', function () {
+    it('emits the same text with no escape sequences', function () {
+        $entries = [
+            new LogEntry(
+                timestamp: '2026-01-07 10:30:00',
+                channel: 'web',
+                level: 'error',
+                category: 'app\\Service',
+                message: 'Error occurred',
+                file: 'web.log',
+                stackTrace: [new StackFrame(0, '/file.php', 1, 'test()')],
+            ),
+        ];
+
+        $plain = formatLogs($entries, color: false)->text;
+
+        expect($plain)->not->toContain("\033")
+            ->and($plain)->toContain('2026-01-07 10:30:00')
+            ->and($plain)->toContain('[ERROR]')
+            ->and($plain)->toContain('app\\Service: Error occurred')
+            ->and($plain)->toContain('  #0 /file.php(1): test()');
+    });
+
+    it('lays out identically to the coloured output', function () {
+        $entries = [
+            new LogEntry(
+                timestamp: '2026-01-07 10:30:00',
+                channel: 'web',
+                level: 'warning',
+                category: 'app',
+                message: 'Careful',
+                file: 'web.log',
+            ),
+        ];
+
+        $stripped = preg_replace('/\033\[[0-9;]*m/', '', formatLogs($entries)->text);
+
+        expect($stripped)->toBe(formatLogs($entries, color: false)->text);
     });
 });

--- a/tests/Unit/Support/PaletteTest.php
+++ b/tests/Unit/Support/PaletteTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 3) . '/vendor/yiisoft/yii2/Yii.php';
+
+use stimmt\craft\Mcp\support\Ansi;
+use stimmt\craft\Mcp\support\Palette;
+
+describe('Palette when colour is off', function () {
+    it('returns every role unchanged', function (string $role) {
+        $palette = new Palette(false);
+
+        expect($palette->{$role}('text'))->toBe('text');
+    })->with(['heading', 'key', 'muted', 'subtle', 'error', 'warning']);
+
+    it('emits no escape sequence at all', function () {
+        $palette = new Palette(false);
+
+        $painted = $palette->heading('a') . $palette->key('b') . $palette->muted('c')
+            . $palette->subtle('d') . $palette->error('e') . $palette->warning('f');
+
+        expect($painted)->toBe('abcdef')
+            ->and($painted)->not->toContain("\033");
+    });
+
+    it('reports itself as disabled', function () {
+        expect((new Palette(false))->enabled())->toBeFalse();
+    });
+});
+
+describe('Palette when colour is on', function () {
+    it('wraps each role in its own escape sequence', function (string $role, string $style) {
+        $palette = new Palette(true);
+
+        expect($palette->{$role}('text'))->toBe($style . 'text' . Ansi::RESET);
+    })->with([
+        ['heading', Ansi::BOLD],
+        ['key', Ansi::CYAN],
+        ['muted', Ansi::DIM],
+        ['subtle', Ansi::GRAY],
+        ['error', Ansi::RED],
+        ['warning', Ansi::YELLOW],
+    ]);
+
+    it('reports itself as enabled', function () {
+        expect((new Palette(true))->enabled())->toBeTrue();
+    });
+});
+
+describe('Palette::fromSettings()', function () {
+    it('is off when the install has not opted in', function () {
+        expect(Palette::fromSettings()->enabled())->toBeFalse();
+    });
+});

--- a/tests/Unit/Support/PresenterTest.php
+++ b/tests/Unit/Support/PresenterTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use Mcp\Capability\Registry\ElementReference;
+use Mcp\Capability\Registry\PromptReference;
+use Mcp\Capability\Registry\ReferenceHandlerInterface;
+use Mcp\Capability\Registry\ToolReference;
+use Mcp\Schema\Content\ImageContent;
+use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\Prompt;
+use Mcp\Schema\Result\CallToolResult;
+use Mcp\Schema\Tool;
+use stimmt\craft\Mcp\enums\ResponseFormat;
+use stimmt\craft\Mcp\support\Palette;
+use stimmt\craft\Mcp\support\Presenter;
+use stimmt\craft\Mcp\support\Renderer;
+
+/**
+ * A reference handler that returns whatever the test hands it, standing in for
+ * the SDK's reflection-based one.
+ */
+function returning(mixed $result): ReferenceHandlerInterface {
+    return new class ($result) implements ReferenceHandlerInterface {
+        public function __construct(private readonly mixed $result) {
+        }
+
+        public function handle(ElementReference $reference, array $arguments): mixed {
+            return $this->result;
+        }
+    };
+}
+
+function toolReference(bool $declaresOutput = false): ToolReference {
+    $properties = $declaresOutput
+        ? ['output' => ['type' => 'string', 'enum' => array_column(ResponseFormat::cases(), 'value')]]
+        : [];
+
+    return new ToolReference(
+        new Tool('demo', null, ['type' => 'object', 'properties' => $properties], 'Demo', null),
+        static fn (): array => [],
+    );
+}
+
+function present(mixed $result, array $arguments = [], bool $declaresOutput = false): mixed {
+    $presenter = new Presenter(returning($result), new Renderer(new Palette(false)));
+
+    return $presenter->handle(toolReference($declaresOutput), $arguments);
+}
+
+describe('Presenter payload duplication', function () {
+    it('carries an array payload exactly once, with no structuredContent', function () {
+        $result = present(['count' => 1, 'sites' => [['id' => 1]]]);
+
+        expect($result)->toBeInstanceOf(CallToolResult::class)
+            ->and($result->structuredContent)->toBeNull()
+            ->and($result->content)->toHaveCount(1);
+
+        $wire = $result->jsonSerialize();
+
+        expect($wire)->not->toHaveKey('structuredContent');
+    });
+
+    it('encodes the array into the single content item without losing a field', function () {
+        $result = present(['count' => 1, 'handle' => 'default']);
+
+        $decoded = json_decode($result->content[0]->text, true);
+
+        expect($decoded)->toBe(['count' => 1, 'handle' => 'default']);
+    });
+});
+
+describe('Presenter pass-through', function () {
+    it('leaves prompt and resource references alone', function () {
+        $presenter = new Presenter(returning(['raw' => true]), new Renderer(new Palette(false)));
+        $reference = new PromptReference(new Prompt('demo', null, null, null), static fn (): array => []);
+
+        expect($presenter->handle($reference, []))->toBe(['raw' => true]);
+    });
+
+    it('leaves a tool that already built its own result alone', function () {
+        $own = CallToolResult::error([new TextContent('boom')]);
+
+        expect(present($own))->toBe($own);
+    });
+
+    it('wraps a single Content return without adding structuredContent', function () {
+        $result = present(new TextContent('> $x\n= 1'));
+
+        expect($result)->toBeInstanceOf(CallToolResult::class)
+            ->and($result->structuredContent)->toBeNull()
+            ->and($result->content)->toHaveCount(1)
+            ->and($result->content[0]->text)->toBe('> $x\n= 1');
+    });
+
+    it('keeps a mixed content list intact', function () {
+        $result = present([new TextContent('a'), new ImageContent('data', 'image/png')]);
+
+        expect($result->content)->toHaveCount(2)
+            ->and($result->structuredContent)->toBeNull();
+    });
+});
+
+describe('Presenter text output', function () {
+    it('renders the payload as text when the tool declares output and the caller asks', function () {
+        $result = present(
+            ['count' => 1, 'handle' => 'default'],
+            ['output' => 'text'],
+            declaresOutput: true,
+        );
+
+        expect($result->content[0]->text)->toBe("count:  1\nhandle: default")
+            ->and($result->structuredContent)->toBeNull();
+    });
+
+    it('stays structured when the caller asks for structured', function () {
+        $result = present(
+            ['count' => 1],
+            ['output' => 'structured'],
+            declaresOutput: true,
+        );
+
+        expect(json_decode($result->content[0]->text, true))->toBe(['count' => 1]);
+    });
+
+    it('never guesses for a tool that does not declare the parameter', function () {
+        $result = present(['count' => 1], ['output' => 'text']);
+
+        expect(json_decode($result->content[0]->text, true))->toBe(['count' => 1]);
+    });
+
+    it('ignores an output value that is not a response format', function () {
+        $result = present(['count' => 1], ['output' => 'dump'], declaresOutput: true);
+
+        expect(json_decode($result->content[0]->text, true))->toBe(['count' => 1]);
+    });
+
+    it('accepts an already-cast enum argument', function () {
+        $result = present(
+            ['count' => 1],
+            ['output' => ResponseFormat::TEXT],
+            declaresOutput: true,
+        );
+
+        expect($result->content[0]->text)->toBe('count: 1');
+    });
+});

--- a/tests/Unit/Support/RendererTest.php
+++ b/tests/Unit/Support/RendererTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+use stimmt\craft\Mcp\support\Palette;
+use stimmt\craft\Mcp\support\Renderer;
+
+function renderPlain(array $payload): string {
+    return (new Renderer(new Palette(false)))->render($payload);
+}
+
+describe('Renderer key-value maps', function () {
+    it('aligns a flat map and keeps JSON scalar semantics readable', function () {
+        $text = renderPlain([
+            'driver' => 'mysql',
+            'serverVersion' => '8.0.35',
+            'port' => 3306,
+            'primary' => true,
+            'charset' => null,
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+            driver:        mysql
+            serverVersion: 8.0.35
+            port:          3306
+            primary:       true
+            charset:       null
+            TEXT);
+    });
+
+    it('renders a count breakdown as an indented block under its key', function () {
+        $text = renderPlain([
+            'total' => 15,
+            'buckets' => ['news' => 12, 'blog' => 3],
+            'groupBy' => 'section',
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+            total:   15
+            buckets:
+              news: 12
+              blog: 3
+            groupBy: section
+            TEXT);
+    });
+
+    it('indents nested maps without flattening them', function () {
+        $text = renderPlain([
+            'site' => [
+                'id' => 1,
+                'handle' => 'default',
+                'group' => ['id' => 3, 'name' => 'Main'],
+            ],
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+            site:
+              id:     1
+              handle: default
+              group:
+                id:   3
+                name: Main
+            TEXT);
+    });
+
+    it('inlines a list of scalars and marks an empty one', function () {
+        $text = renderPlain(['columns' => ['id', 'title'], 'warnings' => []]);
+
+        expect($text)->toBe(<<<'TEXT'
+            columns:  id, title
+            warnings: (empty)
+            TEXT);
+    });
+
+    it('indents a multiline string under its key', function () {
+        $text = renderPlain(['message' => "first\nsecond", 'level' => 'error']);
+
+        expect($text)->toBe(<<<'TEXT'
+            message:
+              first
+              second
+            level: error
+            TEXT);
+    });
+
+    it('marks an empty payload', function () {
+        expect(renderPlain([]))->toBe('(empty)');
+    });
+});
+
+describe('Renderer tables', function () {
+    it('renders a list of uniform rows as an aligned table', function () {
+        $text = renderPlain([
+            'count' => 2,
+            'sites' => [
+                ['id' => 1, 'handle' => 'default', 'primary' => true],
+                ['id' => 2, 'handle' => 'nl', 'primary' => false],
+            ],
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+            count: 2
+            sites:
+              id  handle   primary
+              --  -------  -------
+              1   default  true
+              2   nl       false
+            TEXT);
+    });
+
+    it('renders a top-level list of rows without a key', function () {
+        $text = renderPlain([
+            ['name' => 'entries', 'count' => 12],
+            ['name' => 'assets', 'count' => 3],
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+            name     count
+            -------  -----
+            entries  12
+            assets   3
+            TEXT);
+    });
+
+    it('turns a map of uniform rows into a table keyed by its first column', function () {
+        $text = renderPlain([
+            'elements' => ['label' => 'Total elements', 'count' => 1234],
+            'entries' => ['label' => 'Entries', 'count' => 56],
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+                      label           count
+            --------  --------------  -----
+            elements  Total elements  1234
+            entries   Entries         56
+            TEXT);
+    });
+
+    it('fills a cell the row does not carry rather than dropping the column', function () {
+        $text = renderPlain([
+            'rows' => [
+                ['name' => 'entries', 'count' => 12],
+                ['name' => 'ghost', 'error' => 'Table does not exist'],
+            ],
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+            rows:
+              name     count  error
+              -------  -----  --------------------
+              entries  12
+              ghost           Table does not exist
+            TEXT);
+    });
+
+    it('falls back to per-item blocks when a row carries a nested value', function () {
+        $text = renderPlain([
+            'entries' => [
+                ['id' => 1, 'fields' => ['title' => 'Hello']],
+                ['id' => 2, 'fields' => ['title' => 'Goodbye']],
+            ],
+        ]);
+
+        expect($text)->toBe(<<<'TEXT'
+            entries:
+              - id: 1
+                fields:
+                  title: Hello
+              - id: 2
+                fields:
+                  title: Goodbye
+            TEXT);
+    });
+});
+
+describe('Renderer fallbacks', function () {
+    it('encodes a value it cannot lay out rather than dropping it', function () {
+        $text = renderPlain(['handler' => (object) ['a' => 1]]);
+
+        expect($text)->toBe('handler: {"a":1}');
+    });
+
+    it('falls back to pretty JSON past the depth limit, losing nothing', function () {
+        $deep = ['depth' => 0];
+        $branch = &$deep;
+        foreach (range(1, 8) as $level) {
+            $branch['next'] = ['depth' => $level];
+            $branch = &$branch['next'];
+        }
+        unset($branch);
+
+        $text = renderPlain($deep);
+
+        expect($text)->toStartWith('depth: 0')
+            ->and($text)->toContain('"depth": 6')
+            ->and($text)->toContain('"depth": 8');
+    });
+
+    it('never throws on a payload it cannot represent', function () {
+        $text = renderPlain(['closure' => static fn (): int => 1]);
+
+        expect($text)->toBeString()->not->toBe('');
+    });
+});
+
+describe('Renderer colour', function () {
+    it('emits no escape sequence when the palette is off', function () {
+        $text = (new Renderer(new Palette(false)))->render([
+            'count' => 1,
+            'rows' => [['id' => 1, 'title' => 'Hello']],
+        ]);
+
+        expect($text)->not->toContain("\033");
+    });
+
+    it('colours keys and table headers when the palette is on', function () {
+        $text = (new Renderer(new Palette(true)))->render([
+            'count' => 1,
+            'rows' => [['id' => 1, 'title' => 'Hello']],
+        ]);
+
+        expect($text)->toContain("\033");
+    });
+
+    it('lays out identically with colour stripped back off', function () {
+        $payload = [
+            'count' => 1,
+            'rows' => [['id' => 1, 'title' => 'Hello']],
+        ];
+
+        $colored = (new Renderer(new Palette(true)))->render($payload);
+        $plain = (new Renderer(new Palette(false)))->render($payload);
+
+        expect(preg_replace('/\033\[[0-9;]*m/', '', $colored))->toBe($plain);
+    });
+});

--- a/tests/Unit/Tools/OutputConventionTest.php
+++ b/tests/Unit/Tools/OutputConventionTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+use Mcp\Capability\Discovery\DocBlockParser;
+use Mcp\Capability\Discovery\SchemaGenerator;
+use Mcp\Capability\Registry\ElementReference;
+use Mcp\Capability\Registry\ReferenceHandlerInterface;
+use Mcp\Capability\Registry\ToolReference;
+use Mcp\Schema\Result\CallToolResult;
+use Mcp\Schema\Tool;
+use stimmt\craft\Mcp\enums\ResponseFormat;
+use stimmt\craft\Mcp\support\Palette;
+use stimmt\craft\Mcp\support\Presenter;
+use stimmt\craft\Mcp\support\Renderer;
+use stimmt\craft\Mcp\tools\DatabaseTools;
+use stimmt\craft\Mcp\tools\EntryTools;
+
+/**
+ * The text view is opt-in by signature: a tool declares
+ * `ResponseFormat $output`, which puts the enum in its JSON schema, and the
+ * Presenter keys off that schema. These tests generate the schema with the
+ * SDK's own generator from the real method signatures, so an opted-in tool
+ * that stops advertising the parameter fails here rather than silently
+ * dropping back to JSON in production.
+ */
+function schemaFor(string $class, string $method): array {
+    return (new SchemaGenerator(new DocBlockParser()))->generate(new ReflectionMethod($class, $method));
+}
+
+function presentPayload(array $schema, array $payload, array $arguments): CallToolResult {
+    $inner = new class ($payload) implements ReferenceHandlerInterface {
+        public function __construct(private readonly array $payload) {
+        }
+
+        public function handle(ElementReference $reference, array $arguments): mixed {
+            return $this->payload;
+        }
+    };
+
+    $reference = new ToolReference(
+        new Tool('demo', null, $schema, null, null),
+        static fn (): array => [],
+    );
+
+    return (new Presenter($inner, new Renderer(new Palette(false))))->handle($reference, $arguments);
+}
+
+describe('tools opted into the text view', function () {
+    it('advertises the response format enum in its schema', function (string $class, string $method) {
+        $schema = schemaFor($class, $method);
+
+        expect($schema['properties']['output']['enum'])
+            ->toBe(array_column(ResponseFormat::cases(), 'value'))
+            ->and($schema['properties']['output']['description'])->toBe(Presenter::OUTPUT_DESCRIPTION)
+            ->and($schema['required'] ?? [])->not->toContain('output');
+    })->with([
+        'run_query' => [DatabaseTools::class, 'runQuery'],
+        'get_table_counts' => [DatabaseTools::class, 'getTableCounts'],
+        'count_entries' => [EntryTools::class, 'countEntries'],
+    ]);
+
+    it('renders run_query rows as a table when text is asked for', function () {
+        $result = presentPayload(
+            schemaFor(DatabaseTools::class, 'runQuery'),
+            [
+                'success' => true,
+                'count' => 2,
+                'columns' => ['id', 'title'],
+                'rows' => [
+                    ['id' => 1, 'title' => 'Hello'],
+                    ['id' => 2, 'title' => 'Goodbye'],
+                ],
+            ],
+            ['output' => 'text'],
+        );
+
+        expect($result->content[0]->text)->toBe(<<<'TEXT'
+            success: true
+            count:   2
+            columns: id, title
+            rows:
+              id  title
+              --  -------
+              1   Hello
+              2   Goodbye
+            TEXT);
+    });
+
+    it('renders a count_entries breakdown as a table of buckets', function () {
+        $result = presentPayload(
+            schemaFor(EntryTools::class, 'countEntries'),
+            [
+                'success' => true,
+                'total' => 50,
+                'buckets' => [
+                    ['key' => '2023-12', 'count' => 18],
+                    ['key' => '2024-01', 'count' => 32],
+                ],
+                'groupBy' => 'month:dateUpdated',
+            ],
+            ['output' => 'text'],
+        );
+
+        expect($result->content[0]->text)->toBe(<<<'TEXT'
+            success: true
+            total:   50
+            buckets:
+              key      count
+              -------  -----
+              2023-12  18
+              2024-01  32
+            groupBy: month:dateUpdated
+            TEXT);
+    });
+
+    it('renders a plain total with no breakdown', function () {
+        $result = presentPayload(
+            schemaFor(EntryTools::class, 'countEntries'),
+            ['success' => true, 'total' => 245, 'groupBy' => null],
+            ['output' => 'text'],
+        );
+
+        expect($result->content[0]->text)->toBe(<<<'TEXT'
+            success: true
+            total:   245
+            groupBy: null
+            TEXT);
+    });
+
+    it('renders get_table_counts as a table keyed by table name', function () {
+        $result = presentPayload(
+            schemaFor(DatabaseTools::class, 'getTableCounts'),
+            [
+                'entries' => ['label' => 'Entries', 'count' => 56],
+                'assets' => ['label' => 'Assets', 'count' => 4],
+            ],
+            ['output' => 'text'],
+        );
+
+        expect($result->content[0]->text)->toBe(<<<'TEXT'
+                     label    count
+            -------  -------  -----
+            entries  Entries  56
+            assets   Assets   4
+            TEXT);
+    });
+
+    it('still returns the JSON payload by default', function () {
+        $result = presentPayload(
+            schemaFor(DatabaseTools::class, 'getTableCounts'),
+            ['entries' => ['label' => 'Entries', 'count' => 56]],
+            [],
+        );
+
+        expect(json_decode($result->content[0]->text, true))
+            ->toBe(['entries' => ['label' => 'Entries', 'count' => 56]])
+            ->and($result->structuredContent)->toBeNull();
+    });
+});
+
+describe('tinker is not opted in', function () {
+    it('keeps its own unrelated output parameter out of the convention', function () {
+        $schema = schemaFor(stimmt\craft\Mcp\tools\TinkerTools::class, 'tinker');
+
+        expect($schema['properties']['output']['enum'] ?? null)->toBeNull();
+    });
+});


### PR DESCRIPTION
Three related problems in how tool results reach a client, fixed in one layer rather than per tool.

## Every payload was sent twice
The SDK turns an array return into both `content` (JSON-encoded) and `structuredContent` (the array), and `CallToolResult` emits both. No tool here declares an `outputSchema`, so the duplicate carried nothing a client could validate against while doubling the wire and token cost of every call.

A presenter decorating `ReferenceHandlerInterface` now builds the `CallToolResult` itself, so the payload appears once. `content` is mandatory and universally read, so nothing loses data.

The test drives the real `CallToolHandler` twice, with and without the presenter, and asserts the duplicated shape explicitly in the "without" case, so the regression cannot return quietly.

## Human-readable output was hand-rolled per tool
`tinker` and `read_logs` had each built their own formatter. There is now one renderer for the shapes this plugin actually returns: uniform rows as an aligned table, key-value data and breakdowns as aligned blocks, nesting indented, and pretty JSON as the fallback for anything that will not lay out cleanly, so no data is ever lost to formatting.

A tool opts in by declaring an `output` parameter, nothing more; rendering happens centrally. `run_query`, `get_table_counts` and `count_entries` opt in here, covering all three shapes the renderer claims to support. Extending it to another tool is one parameter.

## Colour was decided ad hoc
One `colorOutput` setting, off by default, consulted only by the palette. Off is the right default because the usual consumer is an AI client, which receives ANSI escapes as literal noise and pays tokens for it. Turn it on when a person reads this server in a terminal.

Note the behaviour change: `read_logs output="text"` is no longer coloured unconditionally. Its layout is unchanged and `colorOutput: true` restores the colours byte for byte, which the tests pin.

## Verify
`composer ci` (583 passing). Not yet exercised against a live install; the rendering evidence is the suite driving the real SDK handler.
